### PR TITLE
remove unused utm_odom_tf_yaw_

### DIFF
--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -193,10 +193,6 @@ class NavSatTransform
     //!
     double utm_meridian_convergence_;
 
-    //! @brief Stores the yaw we need to compute the transform
-    //!
-    double utm_odom_tf_yaw_;
-
     //! @brief IMU's yaw offset
     //!
     //! Your IMU should read 0 when facing *magnetic* north. If it doesn't, this (parameterized) value gives the offset

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -57,7 +57,6 @@ namespace RobotLocalization
     use_odometry_yaw_(false),
     zero_altitude_(false),
     magnetic_declination_(0.0),
-    utm_odom_tf_yaw_(0.0),
     yaw_offset_(0.0),
     base_link_frame_id_("base_link"),
     gps_frame_id_(""),


### PR DESCRIPTION
With this change, robot_localization doesn't trigger any complaints from scan-build using clang 8.