### PR TITLE
initalize verbose_ flag to fix crashes

### DIFF
--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -67,7 +67,8 @@ namespace RobotLocalization
     transferFunction_(STATE_SIZE, STATE_SIZE),
     transferFunctionJacobian_(STATE_SIZE, STATE_SIZE),
     debugStream_(NULL),
-    debug_(false)
+    debug_(false),
+    verbose_(false)
   {
     reset();
   }


### PR DESCRIPTION
This verbose_ flag was not getting initialized and was causing seg faults. Initializing to false now like debug flag. 