### PR TITLE
Chacalnoir/initialization check

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-robot-localization (102.7.3-focal4) focal; urgency=medium
+
+  * Added bad data check for initialization
+
+ -- chacalnoir <joel.ph.dunham@gmail.com>  Wed, 25 May 2022 06:38:52 -0400
+
 ros-noetic-robot-localization (102.7.3-focal3) focal; urgency=medium
 
   * Initialize verbose flag to avoid writing to unopened ostream

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-robot-localization (102.7.3-focal5) focal; urgency=medium
+
+  * Improved alpha-beta filter handling of edge cases
+
+ -- Joel <joel@greenzie.com>  Wed, 03 Aug 2022 03:21:53 -0400
+
 ros-noetic-robot-localization (102.7.3-focal4) focal; urgency=medium
 
   * Added bad data check for initialization

--- a/include/robot_localization/ekf.h
+++ b/include/robot_localization/ekf.h
@@ -65,6 +65,22 @@ class Ekf: public FilterBase
     //!
     ~Ekf();
 
+    //! @brief Prepares the correction up to the outlier rejection, after which correct() integrates
+    //! the prepared correction
+    //!
+    //! @param[in] measurement - The measurement to prepare to fuse with the state estimate
+    //! @param[in] updateIndices - The indexes of the measurement that will be used to update the state
+    //! @param[out] innovationSubset - The innovation which applies to the subset of the state that matches the measurement
+    //! @param[out] measurementCovarianceSubset - The subset of the covariance that applies to this measurement
+    //! @param[out] kalmanGainSubset - The Kalman gain which applies to the subset of the state that matches the measurement
+    //! @param[out] hphrInv - Used for computing the Kalman gain and checking the Mahalanobis distance
+    //! @param[out] stateToMeasurementSubset - Used for computing the Kalman gain and gain residual
+    //!
+    void prepareCorrect(const Measurement &measurement, const std::vector<size_t> &updateIndices,
+                        Eigen::VectorXd &innovationSubset, Eigen::MatrixXd &measurementCovarianceSubset,
+                        Eigen::MatrixXd &kalmanGainSubset, Eigen::MatrixXd &hphrInv,
+                        Eigen::MatrixXd &stateToMeasurementSubset);
+
     //! @brief Carries out the correct step in the predict/update cycle.
     //!
     //! @param[in] measurement - The measurement to fuse with our estimate

--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -66,6 +66,9 @@ struct Measurement
   // The Mahalanobis distance threshold in number of sigmas
   double mahalanobisThresh_;
 
+  // The Mahalanobis distance threshold for initialization in number of sigmas
+  double mahalanobisThreshInit_;
+
   // The real-valued time, in seconds, since some epoch
   // (presumably the start of execution, but any will do)
   double time_;
@@ -101,6 +104,7 @@ struct Measurement
   Measurement() :
     latestControlTime_(0.0),
     mahalanobisThresh_(std::numeric_limits<double>::max()),
+    mahalanobisThreshInit_(std::numeric_limits<double>::max()),
     time_(0.0),
     topicName_("")
   {
@@ -166,6 +170,28 @@ class FilterBase
     //! @param[in] state - The STATE_SIZE state vector that is used to generate the dynamic process noise covariance
     //!
     void computeDynamicProcessNoiseCovariance(const Eigen::VectorXd &state, const double delta);
+
+    //! @brief Finds the update indices for the given measurement
+    //!
+    //! @param[in] measurement - The measurement for which to get the update indices of the state
+    //! @param[out] updateIndices - The indices of the state to which this measurement applies
+    void getUpdateIndices(const Measurement &measurement, std::vector<size_t> &updateIndices);
+
+    //! @brief Prepares the correction up to the outlier rejection, after which correct() integrates
+    //! the prepared correction
+    //!
+    //! @param[in] measurement - The measurement to prepare to fuse with the state estimate
+    //! @param[in] updateIndices - The indexes of the measurement that will be used to update the state
+    //! @param[out] innovationSubset - The innovation which applies to the subset of the state that matches the measurement
+    //! @param[out] measurementCovarianceSubset - The subset of the covariance that applies to this measurement
+    //! @param[out] kalmanGainSubset - The Kalman gain which applies to the subset of the state that matches the measurement
+    //! @param[out] innovMatInv - Used for computing the Kalman gain and checking the Mahalanobis distance - name more precisely defined in derived classes
+    //! @param[out] auxMat - Auxiliary matrix - name more precisely defined in derived classes
+    //!
+    virtual void prepareCorrect(const Measurement &measurement, const std::vector<size_t> &updateIndices,
+                                Eigen::VectorXd &innovationSubset, Eigen::MatrixXd &measurementCovarianceSubset,
+                                Eigen::MatrixXd &kalmanGainSubset, Eigen::MatrixXd &innovMatInv,
+                                Eigen::MatrixXd &auxMat) = 0;
 
     //! @brief Carries out the correct step in the predict/update cycle. This method
     //! must be implemented by subclasses.

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -82,13 +82,15 @@ struct CallbackData
                const int updateSum,
                const bool differential,
                const bool relative,
-               const double rejectionThreshold) :
+               const double rejectionThreshold,
+               const double rejectionThresholdInit) :
     topicName_(topicName),
     updateVector_(updateVector),
     updateSum_(updateSum),
     differential_(differential),
     relative_(relative),
-    rejectionThreshold_(rejectionThreshold)
+    rejectionThreshold_(rejectionThreshold),
+    rejectionThresholdInit_(rejectionThresholdInit)
   {
   }
 
@@ -98,6 +100,7 @@ struct CallbackData
   bool differential_;
   bool relative_;
   double rejectionThreshold_;
+  double rejectionThresholdInit_;
 };
 
 struct ImuDynamicCorrectionData
@@ -203,6 +206,7 @@ template<class T> class RosFilter
     //! @param[in] measurementCovariance - The covariance of the measurement
     //! @param[in] updateVector - The boolean vector that specifies which variables to update from this measurement
     //! @param[in] mahalanobisThresh - Threshold, expressed as a Mahalanobis distance, for outlier rejection
+    //! @param[in] mahalanobisThreshInit - Threshold, expressed as a Mahalanobis distance, for initialization data rejection
     //! @param[in] time - The time of arrival (in seconds)
     //!
     void enqueueMeasurement(const std::string &topicName,
@@ -210,6 +214,7 @@ template<class T> class RosFilter
                             const Eigen::MatrixXd &measurementCovariance,
                             const std::vector<int> &updateVector,
                             const double mahalanobisThresh,
+                            const double mahalanobisThreshInit,
                             const ros::Time &time);
 
     //! @brief Method for zeroing out 3D variables within measurements

--- a/include/robot_localization/ukf.h
+++ b/include/robot_localization/ukf.h
@@ -72,6 +72,22 @@ class Ukf: public FilterBase
     //!
     ~Ukf();
 
+    //! @brief Prepares the correction up to the outlier rejection, after which correct() integrates
+    //! the prepared correction
+    //!
+    //! @param[in] measurement - The measurement to prepare to fuse with the state estimate
+    //! @param[in] updateIndices - The indexes of the measurement that will be used to update the state
+    //! @param[out] innovationSubset - The innovation which applies to the subset of the state that matches the measurement
+    //! @param[out] measurementCovarianceSubset - The subset of the covariance that applies to this measurement
+    //! @param[out] kalmanGainSubset - The Kalman gain which applies to the subset of the state that matches the measurement
+    //! @param[out] invInnovCov - Used for computing the Kalman gain and checking the Mahalanobis distance
+    //! @param[out] predictedMeasCovar - Used for computing the Kalman gain and estimate error covariance
+    //!
+    void prepareCorrect(const Measurement &measurement, const std::vector<size_t> &updateIndices,
+                        Eigen::VectorXd &innovationSubset, Eigen::MatrixXd &measurementCovarianceSubset,
+                        Eigen::MatrixXd &kalmanGainSubset, Eigen::MatrixXd &invInnovCov,
+                        Eigen::MatrixXd &predictedMeasCovar);
+
     //! @brief Carries out the correct step in the predict/update cycle.
     //!
     //! @param[in] measurement - The measurement to fuse with our estimate

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -52,40 +52,14 @@ namespace RobotLocalization
   {
   }
 
-  void Ekf::correct(const Measurement &measurement)
+  void Ekf::prepareCorrect(const Measurement &measurement, const std::vector<size_t> &updateIndices,
+                           Eigen::VectorXd &innovationSubset, Eigen::MatrixXd &measurementCovarianceSubset,
+                           Eigen::MatrixXd &kalmanGainSubset, Eigen::MatrixXd &hphrInv,
+                           Eigen::MatrixXd &stateToMeasurementSubset)
   {
-    FB_DEBUG("---------------------- Ekf::correct ----------------------\n" <<
-             "State is:\n" << state_ << "\n"
-             "Topic is:\n" << measurement.topicName_ << "\n"
-             "Measurement is:\n" << measurement.measurement_ << "\n"
-             "Measurement topic name is:\n" << measurement.topicName_ << "\n\n"
-             "Measurement covariance is:\n" << measurement.covariance_ << "\n");
-
     // We don't want to update everything, so we need to build matrices that only update
     // the measured parts of our state vector. Throughout prediction and correction, we
     // attempt to maximize efficiency in Eigen.
-
-    // First, determine how many state vector values we're updating
-    std::vector<size_t> updateIndices;
-    for (size_t i = 0; i < measurement.updateVector_.size(); ++i)
-    {
-      if (measurement.updateVector_[i])
-      {
-        // Handle nan and inf values in measurements
-        if (std::isnan(measurement.measurement_(i)))
-        {
-          FB_VERBOSE("Value at index " << i << " was nan. Excluding from update.\n");
-        }
-        else if (std::isinf(measurement.measurement_(i)))
-        {
-          FB_VERBOSE("Value at index " << i << " was inf. Excluding from update.\n");
-        }
-        else
-        {
-          updateIndices.push_back(i);
-        }
-      }
-    }
 
     FB_DEBUG("Update indices are:\n" << updateIndices << "\n");
 
@@ -94,17 +68,14 @@ namespace RobotLocalization
     // Now set up the relevant matrices
     Eigen::VectorXd stateSubset(updateSize);                              // x (in most literature)
     Eigen::VectorXd measurementSubset(updateSize);                        // z
-    Eigen::MatrixXd measurementCovarianceSubset(updateSize, updateSize);  // R
-    Eigen::MatrixXd stateToMeasurementSubset(updateSize, state_.rows());  // H
-    Eigen::MatrixXd kalmanGainSubset(state_.rows(), updateSize);          // K
-    Eigen::VectorXd innovationSubset(updateSize);                         // z - Hx
-
     stateSubset.setZero();
     measurementSubset.setZero();
     measurementCovarianceSubset.setZero();
     stateToMeasurementSubset.setZero();
     kalmanGainSubset.setZero();
     innovationSubset.setZero();
+    // Resize since the size may have been unknown generically for the initialization call
+    stateToMeasurementSubset.resize(updateSize, STATE_SIZE);
 
     // Now build the sub-matrices from the full-sized matrices
     for (size_t i = 0; i < updateSize; ++i)
@@ -158,7 +129,7 @@ namespace RobotLocalization
 
     // (1) Compute the Kalman gain: K = (PH') / (HPH' + R)
     Eigen::MatrixXd pht = estimateErrorCovariance_ * stateToMeasurementSubset.transpose();
-    Eigen::MatrixXd hphrInv  = (stateToMeasurementSubset * pht + measurementCovarianceSubset).inverse();
+    hphrInv  = (stateToMeasurementSubset * pht + measurementCovarianceSubset).inverse();
     kalmanGainSubset.noalias() = pht * hphrInv;
 
     innovationSubset = (measurementSubset - stateSubset);
@@ -181,6 +152,32 @@ namespace RobotLocalization
         }
       }
     }
+  }
+
+  void Ekf::correct(const Measurement &measurement)
+  {
+    FB_DEBUG("---------------------- Ekf::correct ----------------------\n" <<
+             "State is:\n" << state_ << "\n"
+             "Topic is:\n" << measurement.topicName_ << "\n"
+             "Measurement is:\n" << measurement.measurement_ << "\n"
+             "Measurement topic name is:\n" << measurement.topicName_ << "\n\n"
+             "Measurement covariance is:\n" << measurement.covariance_ << "\n");
+
+    // Prepare the correction for integration into the state and covariance
+    std::vector<size_t> updateIndices;
+    getUpdateIndices(measurement, updateIndices);
+    size_t updateSize = updateIndices.size();
+    Eigen::VectorXd innovationSubset(updateSize);                      // z - Hx
+    Eigen::MatrixXd kalmanGainSubset(STATE_SIZE, updateSize);          // K
+    Eigen::MatrixXd stateToMeasurementSubset(updateSize, STATE_SIZE);  // H
+    Eigen::MatrixXd measurementCovarianceSubset(updateSize, updateSize);  // R
+    Eigen::MatrixXd hphrInv;  // TODO - DETERMINE THE SIZE
+    innovationSubset.setZero();
+    kalmanGainSubset.setZero();
+    stateToMeasurementSubset.setZero();
+    measurementCovarianceSubset.setZero();
+    prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
+                   kalmanGainSubset, hphrInv, stateToMeasurementSubset);
 
     // (2) Check Mahalanobis distance between mapped measurement and state.
     if (checkMahalanobisThreshold(innovationSubset, hphrInv, measurement.mahalanobisThresh_))

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -209,6 +209,29 @@ namespace RobotLocalization
     return state_;
   }
 
+  void FilterBase::getUpdateIndices(const Measurement &measurement, std::vector<size_t> &updateIndices)
+  {
+    for (size_t i = 0; i < measurement.updateVector_.size(); ++i)
+    {
+      if (measurement.updateVector_[i])
+      {
+        // Handle nan and inf values in measurements
+        if (std::isnan(measurement.measurement_(i)))
+        {
+          FB_VERBOSE("Value at index " << i << " was nan. Excluding from update.\n");
+        }
+        else if (std::isinf(measurement.measurement_(i)))
+        {
+          FB_VERBOSE("Value at index " << i << " was inf. Excluding from update.\n");
+        }
+        else
+        {
+          updateIndices.push_back(i);
+        }
+      }
+    }
+  }
+
   void FilterBase::processMeasurement(const Measurement &measurement)
   {
     FB_VERBOSE("------ FilterBase::processMeasurement (" << measurement.topicName_ << ") ------\n");
@@ -242,27 +265,54 @@ namespace RobotLocalization
     }
     else
     {
-      FB_VERBOSE("First measurement. Initializing filter.\n");
+      // Prepare the measurement in order to check the initial Mahalanobis threshold
+      std::vector<size_t> updateIndices;
+      getUpdateIndices(measurement, updateIndices);
+      size_t updateSize = updateIndices.size();
+      Eigen::VectorXd innovationSubset(updateSize);
+      Eigen::MatrixXd measurementCovarianceSubset(updateSize, updateSize);
+      Eigen::MatrixXd kalmanGainSubset(STATE_SIZE, updateSize);
+      Eigen::MatrixXd auxMat(updateSize, STATE_SIZE);
+      Eigen::MatrixXd innovMatInv;  // TODO - DETERMINE THE SIZE
+      innovationSubset.setZero();
+      kalmanGainSubset.setZero();
+      measurementCovarianceSubset.setZero();
+      auxMat.setZero();
+      prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
+                     kalmanGainSubset, innovMatInv, auxMat);
 
-      // Initialize the filter, but only with the values we're using
-      size_t measurementLength = measurement.updateVector_.size();
-      for (size_t i = 0; i < measurementLength; ++i)
+      if (checkMahalanobisThreshold(innovationSubset, innovMatInv, measurement.mahalanobisThreshInit_))
       {
-        state_[i] = (measurement.updateVector_[i] ? measurement.measurement_[i] : state_[i]);
-      }
+        FB_VERBOSE("First measurement. Initializing filter.\n");
 
-      // Same for covariance
-      for (size_t i = 0; i < measurementLength; ++i)
-      {
-        for (size_t j = 0; j < measurementLength; ++j)
+        // Initialize the filter, but only with the values we're using
+        size_t measurementLength = measurement.updateVector_.size();
+        for (size_t i = 0; i < measurementLength; ++i)
         {
-          estimateErrorCovariance_(i, j) = (measurement.updateVector_[i] && measurement.updateVector_[j] ?
-                                            measurement.covariance_(i, j) :
-                                            estimateErrorCovariance_(i, j));
+          state_[i] = (measurement.updateVector_[i] ? measurement.measurement_[i] : state_[i]);
+        }
+
+        // Same for covariance
+        for (size_t i = 0; i < measurementLength; ++i)
+        {
+          for (size_t j = 0; j < measurementLength; ++j)
+          {
+            estimateErrorCovariance_(i, j) = (measurement.updateVector_[i] && measurement.updateVector_[j] ?
+                                              measurement.covariance_(i, j) :
+                                              estimateErrorCovariance_(i, j));
+          }
+        }
+
+        initialized_ = true;
+      }
+      else
+      {
+        FB_VERBOSE("First measurement rejected - filter not initialized");
+        if (saveRejectedMeasurementTopics_)
+        {
+          rejectedMeasurementTopics_.push_back(measurement.topicName_);
         }
       }
-
-      initialized_ = true;
     }
 
     if (delta >= 0.0)

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -3095,9 +3095,20 @@ namespace RobotLocalization
               else
               {
                 // Has been initialized - use the alpha-beta filter
+                // Use an alternate formulation to enable handling angle wrapping.
+                // new = alpha*previous + (1-alpha)*current => new = alpha*(previous-current) + current
+                // With rotation clamping to the [-pi, pi] range: clampRotation(alpha*clampRotation(previous-current) + current)
+                //  E.g. previous = 175, current = -175, alpha = 0.8 (in degrees for ease of understanding - the real system is in radians)
+                //  Then: new = clampRotation(0.8*clampRotation(175--175) + -175)
+                //  new = clampRotation(0.8*clampRotation(350) - 175)
+                //  new = clampRotation(0.8*-10 - 175)
+                //  new = clampRotation(-8 - 175)
+                //  new = clampRotation(-183)
+                //  new = 177
                 imuDynamicCorrectionData_[topicName].yaw_offset_ =
-                  imuDynamicCorrectionData_[topicName].alpha_ * imuDynamicCorrectionData_[topicName].yaw_offset_ +
-                  (1.0 - imuDynamicCorrectionData_[topicName].alpha_) * yaw_offset;
+                  FilterUtilities::clampRotation(imuDynamicCorrectionData_[topicName].alpha_ *
+                                                 FilterUtilities::clampRotation(imuDynamicCorrectionData_[topicName].yaw_offset_ - yaw_offset) + yaw_offset);
+
                 // Should be added (+) since these are variances.
                 // Note that the variance is not an actual angle, so angle wrapping is not required.
                 imuDynamicCorrectionData_[topicName].yaw_offset_variance_ =

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -3125,7 +3125,12 @@ namespace RobotLocalization
               debug_info += "    IMU offset var: " + std::to_string(imuDynamicCorrectionData_[topicName].yaw_offset_variance_) + " rad^2\n";
               RF_VERBOSE("IMU dynamic correction:\n" << debug_info.c_str());
             }
-            else{
+            else if (imuDynamicCorrectionData_[topicName].last_speed_ > imuDynamicCorrectionData_[topicName].min_speed_) {
+              // Moving fast enough, but variance too high. Log since there is a potential divergence case here.
+              ROS_WARN_STREAM_THROTTLE(2.0, "Cannot update dynamic corrections due to variance limit - check for accurate bias estimate.");
+            }
+            else
+            {
               RF_VERBOSE("Cannot update dynamic correction with speed: " <<
                 std::to_string(imuDynamicCorrectionData_[topicName].last_speed_) << " < " <<
                 imuDynamicCorrectionData_[topicName].min_speed_ << " or yaw variance: " <<

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -258,6 +258,7 @@ namespace RobotLocalization
                            measurementCovariance,
                            updateVectorCorrected,
                            callbackData.rejectionThreshold_,
+                           callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
 
         RF_VERBOSE("Enqueued new measurement for " << topicName << "_acceleration\n");
@@ -334,6 +335,7 @@ namespace RobotLocalization
                                         const Eigen::MatrixXd &measurementCovariance,
                                         const std::vector<int> &updateVector,
                                         const double mahalanobisThresh,
+                                        const double mahalanobisThreshInit,
                                         const ros::Time &time)
   {
     MeasurementPtr meas = MeasurementPtr(new Measurement());
@@ -344,6 +346,7 @@ namespace RobotLocalization
     meas->updateVector_ = updateVector;
     meas->time_ = time.toSec();
     meas->mahalanobisThresh_ = mahalanobisThresh;
+    meas->mahalanobisThreshInit_ = mahalanobisThreshInit;
     meas->latestControl_ = latestControl_;
     meas->latestControlTime_ = latestControlTime_.toSec();
     measurementQueue_.push(meas);
@@ -1117,11 +1120,19 @@ namespace RobotLocalization
         nhLocal_.param(odomTopicName + std::string("_pose_rejection_threshold"),
                        poseMahalanobisThresh,
                        std::numeric_limits<double>::max());
+        double poseMahalanobisThreshInit;
+        nhLocal_.param(odomTopicName + std::string("_pose_rejection_threshold_initialize"),
+                       poseMahalanobisThreshInit,
+                       std::numeric_limits<double>::max());
 
         // Check for twist rejection threshold
         double twistMahalanobisThresh;
         nhLocal_.param(odomTopicName + std::string("_twist_rejection_threshold"),
                        twistMahalanobisThresh,
+                       std::numeric_limits<double>::max());
+        double twistMahalanobisThreshInit;
+        nhLocal_.param(odomTopicName + std::string("_twist_rejection_threshold_initialize"),
+                       twistMahalanobisThreshInit,
                        std::numeric_limits<double>::max());
 
         // Now pull in its boolean update vector configuration. Create separate vectors for pose
@@ -1139,9 +1150,9 @@ namespace RobotLocalization
         nhLocal_.param(odomTopicName + "_queue_size", odomQueueSize, 1);
 
         const CallbackData poseCallbackData(odomTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
-          relative, poseMahalanobisThresh);
+          relative, poseMahalanobisThresh, poseMahalanobisThreshInit);
         const CallbackData twistCallbackData(odomTopicName + "_twist", twistUpdateVec, twistUpdateSum, false, false,
-          twistMahalanobisThresh);
+          twistMahalanobisThresh, twistMahalanobisThresh);
 
         bool nodelayOdom = false;
         nhLocal_.param(odomTopicName + "_nodelay", nodelayOdom, false);
@@ -1243,6 +1254,10 @@ namespace RobotLocalization
         nhLocal_.param(poseTopicName + std::string("_rejection_threshold"),
                        poseMahalanobisThresh,
                        std::numeric_limits<double>::max());
+        double poseMahalanobisThreshInit;
+        nhLocal_.param(poseTopicName + std::string("_rejection_threshold_initialize"),
+                       poseMahalanobisThreshInit,
+                       std::numeric_limits<double>::max());
 
         int poseQueueSize = 1;
         nhLocal_.param(poseTopicName + "_queue_size", poseQueueSize, 1);
@@ -1264,7 +1279,7 @@ namespace RobotLocalization
         if (poseUpdateSum > 0)
         {
           const CallbackData callbackData(poseTopicName, poseUpdateVec, poseUpdateSum, differential, relative,
-            poseMahalanobisThresh);
+            poseMahalanobisThresh, poseMahalanobisThreshInit);
 
           topicSubs_.push_back(
             nh_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(poseTopic, poseQueueSize,
@@ -1325,6 +1340,10 @@ namespace RobotLocalization
         nhLocal_.param(twistTopicName + std::string("_rejection_threshold"),
                        twistMahalanobisThresh,
                        std::numeric_limits<double>::max());
+        double twistMahalanobisThreshInit;
+        nhLocal_.param(twistTopicName + std::string("_rejection_threshold_initialize"),
+                       twistMahalanobisThreshInit,
+                       std::numeric_limits<double>::max());
 
         int twistQueueSize = 1;
         nhLocal_.param(twistTopicName + "_queue_size", twistQueueSize, 1);
@@ -1341,7 +1360,7 @@ namespace RobotLocalization
         if (twistUpdateSum > 0)
         {
           const CallbackData callbackData(twistTopicName, twistUpdateVec, twistUpdateSum, false, false,
-            twistMahalanobisThresh);
+            twistMahalanobisThresh, twistMahalanobisThreshInit);
 
           topicSubs_.push_back(
             nh_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(twistTopic, twistQueueSize,
@@ -1404,17 +1423,29 @@ namespace RobotLocalization
         nhLocal_.param(imuTopicName + std::string("_pose_rejection_threshold"),
                        poseMahalanobisThresh,
                        std::numeric_limits<double>::max());
+        double poseMahalanobisThreshInit;
+        nhLocal_.param(imuTopicName + std::string("_pose_rejection_threshold_initialize"),
+                       poseMahalanobisThreshInit,
+                       std::numeric_limits<double>::max());
 
         // Check for angular velocity rejection threshold
         double twistMahalanobisThresh;
         std::string imuTwistRejectionName =
           imuTopicName + std::string("_twist_rejection_threshold");
         nhLocal_.param(imuTwistRejectionName, twistMahalanobisThresh, std::numeric_limits<double>::max());
+        double twistMahalanobisThreshInit;
+        imuTwistRejectionName =
+          imuTopicName + std::string("_twist_rejection_threshold_initialize");
+        nhLocal_.param(imuTwistRejectionName, twistMahalanobisThreshInit, std::numeric_limits<double>::max());
 
         // Check for acceleration rejection threshold
         double accelMahalanobisThresh;
         nhLocal_.param(imuTopicName + std::string("_linear_acceleration_rejection_threshold"),
                        accelMahalanobisThresh,
+                       std::numeric_limits<double>::max());
+        double accelMahalanobisThreshInit;
+        nhLocal_.param(imuTopicName + std::string("_linear_acceleration_rejection_threshold_initialize"),
+                       accelMahalanobisThreshInit,
                        std::numeric_limits<double>::max());
 
         bool removeGravAcc = false;
@@ -1507,11 +1538,11 @@ namespace RobotLocalization
         if (poseUpdateSum + twistUpdateSum + accelUpdateSum > 0)
         {
           const CallbackData poseCallbackData(imuTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
-            relative, poseMahalanobisThresh);
+            relative, poseMahalanobisThresh, poseMahalanobisThreshInit);
           const CallbackData twistCallbackData(imuTopicName + "_twist", twistUpdateVec, twistUpdateSum, differential,
-            relative, twistMahalanobisThresh);
+            relative, twistMahalanobisThresh, twistMahalanobisThreshInit);
           const CallbackData accelCallbackData(imuTopicName + "_acceleration", accelUpdateVec, accelUpdateSum,
-            differential, relative, accelMahalanobisThresh);
+            differential, relative, accelMahalanobisThresh, accelMahalanobisThreshInit);
 
           topicSubs_.push_back(
             nh_.subscribe<sensor_msgs::Imu>(imuTopic, imuQueueSize,
@@ -1899,6 +1930,7 @@ namespace RobotLocalization
                            measurementCovariance,
                            updateVectorCorrected,
                            callbackData.rejectionThreshold_,
+                           callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
 
         RF_VERBOSE("Enqueued new measurement for " << topicName << "\n");
@@ -2253,6 +2285,7 @@ namespace RobotLocalization
                            measurementCovariance,
                            updateVectorCorrected,
                            callbackData.rejectionThreshold_,
+                           callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
 
         RF_VERBOSE("Enqueued new measurement for " << topicName << "_twist\n");

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -3078,13 +3078,10 @@ namespace RobotLocalization
               // Because the alpha-beta filter is maintaining history, angle wrapping is a problem if not handled.
               //  To correct this, we will always keep the offset in the range [-PI, PI]. The actual yaw angle
               //  wrapping is handled by the Kalman filter. The offset angle wrapping needs to be handled here. The additional step is what
-              //  happens when the angle steps over the boundary (e.g. from -(PI-0.0001) to (PI-0.0001)). That case also has to be handled.
-              //  We could shift the old yaw offset to outside the boundary on the same side as the new yaw offset. That's a bit of work
-              //  for a corner case, so we will instead just skip the alpha-beta filter under those conditions, then running the
-              //  alpha-beta filter again.
+              //  happens when the angle steps over the boundary (e.g. from -(PI-0.0001) to (PI-0.0001)). That is explained and handled in the
+              //  else condition.
               double yaw_offset = FilterUtilities::clampRotation(imuDynamicCorrectionData_[topicName].last_yaw_estimate_ - yaw);
-              if((::fabs(imuDynamicCorrectionData_[topicName].yaw_offset_) < 1e-9) ||
-                (::fabs(yaw_offset - imuDynamicCorrectionData_[topicName].yaw_offset_) > PI))
+              if(::fabs(imuDynamicCorrectionData_[topicName].yaw_offset_) < 1e-9)
               {
                 // Has not been initialized
                 imuDynamicCorrectionData_[topicName].yaw_offset_ = yaw_offset;

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -76,13 +76,11 @@ namespace RobotLocalization
   {
   }
 
-  void Ukf::correct(const Measurement &measurement)
+  void Ukf::prepareCorrect(const Measurement &measurement, const std::vector<size_t> &updateIndices,
+                           Eigen::VectorXd &innovationSubset, Eigen::MatrixXd &measurementCovarianceSubset,
+                           Eigen::MatrixXd &kalmanGainSubset, Eigen::MatrixXd &invInnovCov,
+                           Eigen::MatrixXd &predictedMeasCovar)
   {
-    FB_DEBUG("---------------------- Ukf::correct ----------------------\n" <<
-             "State is:\n" << state_ <<
-             "\nMeasurement is:\n" << measurement.measurement_ <<
-             "\nMeasurement covariance is:\n" << measurement.covariance_ << "\n");
-
     // In our implementation, it may be that after we call predict once, we call correct
     // several times in succession (multiple measurements with different time stamps). In
     // that event, the sigma points need to be updated to reflect the current state.
@@ -95,28 +93,6 @@ namespace RobotLocalization
     // We don't want to update everything, so we need to build matrices that only update
     // the measured parts of our state vector
 
-    // First, determine how many state vector values we're updating
-    std::vector<size_t> updateIndices;
-    for (size_t i = 0; i < measurement.updateVector_.size(); ++i)
-    {
-      if (measurement.updateVector_[i])
-      {
-        // Handle nan and inf values in measurements
-        if (std::isnan(measurement.measurement_(i)))
-        {
-          FB_VERBOSE("Value at index " << i << " was nan. Excluding from update.\n");
-        }
-        else if (std::isinf(measurement.measurement_(i)))
-        {
-          FB_VERBOSE("Value at index " << i << " was inf. Excluding from update.\n");
-        }
-        else
-        {
-          updateIndices.push_back(i);
-        }
-      }
-    }
-
     FB_DEBUG("Update indices are:\n" << updateIndices << "\n");
 
     size_t updateSize = updateIndices.size();
@@ -124,13 +100,9 @@ namespace RobotLocalization
     // Now set up the relevant matrices
     Eigen::VectorXd stateSubset(updateSize);                              // x (in most literature)
     Eigen::VectorXd measurementSubset(updateSize);                        // z
-    Eigen::MatrixXd measurementCovarianceSubset(updateSize, updateSize);  // R
     Eigen::MatrixXd stateToMeasurementSubset(updateSize, STATE_SIZE);     // H
-    Eigen::MatrixXd kalmanGainSubset(STATE_SIZE, updateSize);             // K
-    Eigen::VectorXd innovationSubset(updateSize);                         // z - Hx
     Eigen::VectorXd predictedMeasurement(updateSize);
     Eigen::VectorXd sigmaDiff(updateSize);
-    Eigen::MatrixXd predictedMeasCovar(updateSize, updateSize);
     Eigen::MatrixXd crossCovar(STATE_SIZE, updateSize);
 
     std::vector<Eigen::VectorXd> sigmaPointMeasurements(sigmaPoints_.size(), Eigen::VectorXd(updateSize));
@@ -144,6 +116,8 @@ namespace RobotLocalization
     predictedMeasurement.setZero();
     predictedMeasCovar.setZero();
     crossCovar.setZero();
+    // Resize since the size may have been unknown generically for the initialization call
+    predictedMeasCovar.resize(updateSize, updateSize);
 
     // Now build the sub-matrices from the full-sized matrices
     for (size_t i = 0; i < updateSize; ++i)
@@ -270,7 +244,7 @@ namespace RobotLocalization
     }
 
     // (3) Compute the Kalman gain, making sure to use the actual measurement covariance: K = P_xz * (P_zz + R)^-1
-    Eigen::MatrixXd invInnovCov = (predictedMeasCovar + measurementCovarianceSubset).inverse();
+    invInnovCov = (predictedMeasCovar + measurementCovarianceSubset).inverse();
     kalmanGainSubset = crossCovar * invInnovCov;
 
     // (4) Apply the gain to the difference between the actual and predicted measurements: x = x + K(z - z_hat)
@@ -287,6 +261,32 @@ namespace RobotLocalization
       }
     }
 
+    FB_DEBUG("Cross covariance is:\n" << crossCovar << "\n");
+  }
+
+  void Ukf::correct(const Measurement &measurement)
+  {
+    FB_DEBUG("---------------------- Ukf::correct ----------------------\n" <<
+             "State is:\n" << state_ <<
+             "\nMeasurement is:\n" << measurement.measurement_ <<
+             "\nMeasurement covariance is:\n" << measurement.covariance_ << "\n");
+    
+    // Prepare the correction for integration into the state and covariance
+    std::vector<size_t> updateIndices;
+    getUpdateIndices(measurement, updateIndices);
+    size_t updateSize = updateIndices.size();
+    Eigen::VectorXd innovationSubset(updateSize);                         // z - Hx
+    Eigen::MatrixXd kalmanGainSubset(STATE_SIZE, updateSize);             // K
+    Eigen::MatrixXd measurementCovarianceSubset(updateSize, updateSize);  // R
+    Eigen::MatrixXd predictedMeasCovar(updateSize, updateSize);
+    Eigen::MatrixXd invInnovCov;  // TODO - DETERMINE THE SIZE
+    innovationSubset.setZero();
+    kalmanGainSubset.setZero();
+    predictedMeasCovar.setZero();
+    measurementCovarianceSubset.setZero();
+    prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
+                   kalmanGainSubset, invInnovCov, predictedMeasCovar);
+
     // (5) Check Mahalanobis distance of innovation
     if (checkMahalanobisThreshold(innovationSubset, invInnovCov, measurement.mahalanobisThresh_))
     {
@@ -301,7 +301,6 @@ namespace RobotLocalization
       uncorrected_ = false;
 
       FB_DEBUG("Predicated measurement covariance is:\n" << predictedMeasCovar <<
-               "\nCross covariance is:\n" << crossCovar <<
                "\nKalman gain subset is:\n" << kalmanGainSubset <<
                "\nInnovation:\n" << innovationSubset <<
                "\nCorrected full state is:\n" << state_ <<


### PR DESCRIPTION
Enabling the Mahalanobis distance checks for wheel odometry created issues because bad initialization data (from wheel odometry) caused the filter to initialize incorrectly, which then caused good data to be rejected by the Mahalanobis distance check. This is all because the filter has no capabilities for bad data rejection on initialization. This change request extends the Mahalanobis distance check to the initialization data, with an additional set of parameters (_initialize) to enable separate settings for the initialization data. The initialization Mahalanobis distance check relies on the initial state and covariance settings. If the initial state is unknown, then it is defaulted to zero. The resulting Mahalanobis distance check is then checking how far the initial measurement is from zero. That's why this parameter is separate, because we assume a dynamic start/initialization, so this distance parameter should be large. However, even a large parameter here captures bad data (significant outlier from expected), so this works. The alternative would be to specify maxes and mins, but by adding the additional Mahalanobis distance parameter, we stay consistent with the rest of the settings and only add a single parameters per measurement (e.g. odom0 twist, etc.), which keeps things cleaner and more consistent during configuration.
This has been tested in simulation and works well. Before we move any dependencies to this version, we should test in field systems. If the initialization check is turned off, then it will be the same as we currently run, so it is fully backwards compatible by default. 