### PR TITLE
Chacalnoir/bias estimation improvement

### DIFF
--- a/include/robot_localization/ros_filter_bias_estimator.h
+++ b/include/robot_localization/ros_filter_bias_estimator.h
@@ -26,15 +26,17 @@ class RosFilterBiasEstimator {
          * @param min_speed Minimum speed at which to update the bias estimator
          * @param max_variance Maximum variance at which to update the estimator
          * @param alpha Alpha term of the alpha-beta filter for the bias estimator
-         * @param max_divergence Maximum divergence between the feeder estimator and this estimator before rejecting the inputs
+         * @param max_divergence Maximum divergence between the feeder estimator and this estimator before rejecting the inputs (default is -1 meaning no check)
          * @param max_num_divergences: Maximum number of divergences before no longer trying to correct. 0 means infinite.
+         * @param initial_delay: double delay assuming the uncorrected EKF yaw estimate may be inaccurate for a bit
          * @param is_valid Enables defaulting the validity to false until confirmed by an external system
          */
         RosFilterBiasEstimator(const double min_speed,
                                const double max_variance,
                                const double alpha,
-                               const double max_divergence = M_PI * 2.0,
+                               const double max_divergence = -1.0,
                                const int max_num_divergences = 0,
+                               const double initial_delay = 0.0,
                                const bool is_valid = false);
     
         RosFilterBiasEstimator(const RosFilterBiasEstimator& right);
@@ -123,6 +125,8 @@ class RosFilterBiasEstimator {
         bool is_valid() const { return is_valid_; }
         void set_is_using_data( bool is_using ) { using_data_ = is_using; }
         bool is_using_data() const { return using_data_; }
+        void set_initial_delay(double initial_delay) { initial_delay_ = initial_delay; }
+        double get_initial_delay() const { return initial_delay_; }
     private:
         // Time of last state received in seconds
         double uncorrected_state_received_s_{0.0};
@@ -167,6 +171,15 @@ class RosFilterBiasEstimator {
 
         // Whether no longer trying again
         int num_exceeded_max_divergence_{ 0 };
+
+        // Initial delay assuming uncorrected KF yaw estimate may be incorrect for a bit
+        double initial_delay_{ 0.0 };
+
+        // For handling the initial delay
+        double start_time_{ 0.0 };
+
+        // To avoid constantly checking time differences
+        bool initial_delay_met_{ false };
 
         // Handling the times for the divergence test to determine whether it is valid
         int divergence_test_counter_[ESTIMATION_AXES] = {-1, -1, -1};

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1610,6 +1610,11 @@ namespace RobotLocalization
               std::string correction_alpha = dynamic_magnetometer_correction + std::string("_alpha");
               double alpha = 0.0;  // Full reliance on new measurement by default
               nhLocal_.param(correction_alpha, alpha, alpha);
+              if( alpha > 1.0)
+              {
+                ROS_WARN("Alpha must be <= 1.0 to be valid. Resetting from %10.5f to 1.0", alpha);
+                alpha = 1.0;
+              }
 
               std::string correction_max_divergence = dynamic_magnetometer_correction + std::string("_max_divergence");
               double max_divergence = M_PI * 2.0;  // Any divergence by default

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1607,6 +1607,10 @@ namespace RobotLocalization
               double max_variance = M_PI * M_PI;  // Accept unknown angles by default
               nhLocal_.param(correction_max_variance, max_variance, max_variance);
 
+              std::string correction_initial_delay = dynamic_magnetometer_correction + std::string("_initial_delay");
+              double initial_delay = 0.0;  // Default no initial delay
+              nhLocal_.param(correction_initial_delay, initial_delay, initial_delay);
+
               std::string correction_alpha = dynamic_magnetometer_correction + std::string("_alpha");
               double alpha = 0.0;  // Full reliance on new measurement by default
               nhLocal_.param(correction_alpha, alpha, alpha);
@@ -1628,7 +1632,8 @@ namespace RobotLocalization
               std::string dynamic_correction_topic = imuTopicName + std::string("_pose");
               imuDynamicCorrectionData_.insert(std::pair<std::string const, RosFilterBiasEstimator>(
                 dynamic_correction_topic, RosFilterBiasEstimator(min_speed, max_variance, alpha,
-                max_divergence, max_exceeding, false)));  // Default to invalid unless confirmed via an external system
+                max_divergence, max_exceeding, initial_delay,
+                false)));  // Default to invalid unless confirmed via an external system
               // Set the dynamic corrections axes
               std::vector<bool> dynamic_correction_axes;
               dynamic_correction_axes.push_back((poseUpdateVec[StateMemberRoll] > 0) ? true : false);

--- a/src/ros_filter_bias_estimator.cpp
+++ b/src/ros_filter_bias_estimator.cpp
@@ -13,12 +13,14 @@ RosFilterBiasEstimator::RosFilterBiasEstimator(const double min_speed,
                                                const double alpha,
                                                const double max_divergence,
                                                const int max_num_divergences,
+                                               const double initial_delay,
                                                const bool is_valid) {
     set_min_speed(min_speed);
     set_max_orientation_variance(max_variance);
     set_alpha(alpha);
     set_max_divergence(max_divergence);
     set_max_num_divergences(max_num_divergences);
+    set_initial_delay(initial_delay);
     set_valid(is_valid);
 }
 
@@ -53,6 +55,8 @@ void RosFilterBiasEstimator::reset() {
     }
     uncorrected_orientation_estimate_.setZero();
     num_exceeded_max_divergence_ = 0;
+    start_time_ = 0.0;
+    initial_delay_met_ = false;
     mtx_.unlock();
 }
 
@@ -118,6 +122,8 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                             orientation_offset_[axis] = offset;
                             // Should be added (+) since these are variances
                             orientation_offset_variance_[axis] = measurement_variance[axis] + uncorrected_orientation_variance_[axis];
+                            // Set the start time to handle the delay
+                            start_time_ = time_s;
                         }
                         else
                         {
@@ -140,10 +146,15 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                             orientation_offset_variance_[axis] = alpha_ * orientation_offset_variance_[axis] +
                                 (1.0 - alpha_) * (uncorrected_orientation_variance_[axis] + measurement_variance[axis]);
                         }
+                        // Handle the initial delay - may be immediate if no delay set
+                        initial_delay_met_ |= ((time_s - start_time_) > initial_delay_);
+
                         // Calculate the difference between the two filters estimates
                         double abs_filter_difference = ::fabs(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]);
+
                         // Dropped below limit or calculated once with no limit
-                        orientation_offset_has_been_set_[axis] |= (abs_filter_difference < max_divergence_) | (max_divergence_ < 1e-9);
+                        orientation_offset_has_been_set_[axis] |= (initial_delay_met_) &&
+                            ((abs_filter_difference < max_divergence_) | (max_divergence_ < 1e-9));
 
                         // Handle the divergence test initialization
                         if(was_updating == false) {

--- a/src/ros_filter_bias_estimator.cpp
+++ b/src/ros_filter_bias_estimator.cpp
@@ -148,7 +148,7 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                                 (1.0 - alpha_) * (uncorrected_orientation_variance_[axis] + measurement_variance[axis]);
                         }
                         // Handle the initial delay - may be immediate if no delay set
-                        initial_delay_met_ |= ((time_s - start_time_) > initial_delay_);
+                        initial_delay_met_ |= ((time_s - start_time_) >= initial_delay_);
 
                         // Calculate the difference between the uncorrected filter estimate and the corrected magnetometer value
                         double abs_filter_to_mag_difference = ::fabs(uncorrected_orientation_estimate_[axis] -

--- a/src/ros_filter_bias_estimator.cpp
+++ b/src/ros_filter_bias_estimator.cpp
@@ -84,15 +84,16 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
         if(estimation_axes_[axis])
         {
             // Set based on external system. Can be switched to false later based on internal tests
+            // Also include the lockout from too many failures
             bool can_still_update = (max_num_divergences_ < 1) || (num_exceeded_max_divergence_ < max_num_divergences_);
             is_valid.push_back(is_valid_ && can_still_update);
             // For logging
             std::string axis_name = (axis == 0) ? "roll" : (axis == 1) ? "pitch" : "yaw";
-            if ((uncorrected_state_received_s_ > 0.0) && ((time_s - uncorrected_state_received_s_) < sensor_timeout))
+            if (is_valid[axis]) // Only move forward if still valid
             {
-                if (is_valid[axis])
+                if ((uncorrected_state_received_s_ > 0.0) && ((time_s - uncorrected_state_received_s_) < sensor_timeout))
                 {
-                    // Has valid data for updating the offset estimate
+                    // Has current, valid data for updating the offset estimate
                     if((uncorrected_orientation_variance_[axis] < max_orientation_variance_) && (uncorrected_speed_ > min_speed_))
                     {
                         // For handling the required time until can run a divergence check
@@ -185,6 +186,7 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                         // Moving fast enough, but variance too high. Log since there is a potential divergence case here.
                         RF_TOOLS_VERBOSE("Cannot update dynamic corrections due to variance limit - check for accurate bias estimate.");
                         orientation_offset_is_updating_[axis] = false;  // Not updating
+                        // Don't update the estimate, but keep the bias set since it's just avoiding noise at the moment
                     }
                     else
                     {
@@ -213,46 +215,44 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                         orientation_offset_is_updating_[axis] = false;  // Not updating
                     }
                 }
-                else
+                else if (orientation_offset_has_been_set_[axis])
                 {
-                    orientation_offset_is_updating_[axis] = false;  // No longer updating, but still set
-                    // Invalid - don't update the offset estimate, and can still not use the data
-                }
-            }
-            else if (orientation_offset_has_been_set_[axis])
-            {
-                // Only warn if already has received the data. Otherwise, a ton of warnings
-                //  during initialization.
-                RF_TOOLS_DEBUG("Stale state data for use in calculating " + axis_name + " offset\n");
-                orientation_offset_is_updating_[axis] = false;  // Not updating
-            }
-            if(is_valid[axis])
-            {
-                if (orientation_offset_has_been_set_[axis])  // Calculated at least once (these don't time out)
-                {
-                    orientation_measurement[axis] += orientation_offset_[axis];
-                    measurement_variance[axis] += orientation_offset_variance_[axis];
-
-                    std::string debug_info;
-                    debug_info += "    Corrected IMU " + axis_name + ": " + std::to_string(orientation_measurement[axis] * 180 / M_PI) + " deg\n";
-                    debug_info += "    Corrected IMU var: " + std::to_string(measurement_variance[axis]) + " rad^2\n";
-                    RF_TOOLS_VERBOSE("IMU dynamic correction:\n" << debug_info.c_str());
-                }
-                else
-                {
-                    RF_TOOLS_VERBOSE("No offset information for " + axis_name + "\n");
-                    // Cannot create the pose measurement yet - there is no offset information or it has been flagged as invalid
-                    is_valid[axis] = false;
+                    // Only warn if already has received the data. Otherwise, a ton of warnings
+                    //  during initialization.
+                    RF_TOOLS_DEBUG("Stale state data for use in calculating " + axis_name + " offset\n");
+                    orientation_offset_is_updating_[axis] = false;  // Not updating
+                    // Note: do not reset the has_been_set flag since it's possibly just running at a different rate
                 }
             }
             else
             {
-                RF_TOOLS_VERBOSE("Invalid data for axis " << axis_name << ". Not updating.\n");
+                // Invalid data - cannot update, so don't use it
+                orientation_offset_has_been_set_[axis] = false;  // Prep for a smooth restart
+                orientation_offset_is_updating_[axis] = false;  // No longer updating
+            }
+
+            // Independently check since this is different than whether the data itself is valid
+            if (orientation_offset_has_been_set_[axis])  // Calculated at least once
+            {
+                orientation_measurement[axis] += orientation_offset_[axis];
+                measurement_variance[axis] += orientation_offset_variance_[axis];
+
+                std::string debug_info;
+                debug_info += "    Corrected IMU " + axis_name + ": " + std::to_string(orientation_measurement[axis] * 180 / M_PI) + " deg\n";
+                debug_info += "    Corrected IMU var: " + std::to_string(measurement_variance[axis]) + " rad^2\n";
+                RF_TOOLS_VERBOSE("IMU dynamic correction:\n" << debug_info.c_str());
+            }
+            else
+            {
+                RF_TOOLS_VERBOSE("Unavailable offset information for " + axis_name + "\n");
+                // Cannot create the pose measurement yet - there is no offset information or it has been flagged as invalid
+                is_valid[axis] = false;
             }
         }
         else
         {
-            is_valid.push_back(false);  // Not being used/estimated
+            // Not being used/estimated
+            is_valid.push_back(false);
         }
     }
     mtx_.unlock();

--- a/src/ros_filter_bias_estimator.cpp
+++ b/src/ros_filter_bias_estimator.cpp
@@ -39,6 +39,7 @@ RosFilterBiasEstimator::RosFilterBiasEstimator(const RosFilterBiasEstimator& rig
     right.get_estimation_axes(estimation_axes);
     set_estimation_axes(estimation_axes);
     set_max_num_divergences(right.get_max_num_divergences());
+    set_initial_delay(right.get_initial_delay());
 }
 
 void RosFilterBiasEstimator::reset() {

--- a/src/ros_filter_bias_estimator.cpp
+++ b/src/ros_filter_bias_estimator.cpp
@@ -154,8 +154,8 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                         double abs_filter_difference = ::fabs(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]);
 
                         // Dropped below limit or calculated once with no limit
-                        orientation_offset_has_been_set_[axis] |= (initial_delay_met_) &&
-                            ((abs_filter_difference < max_divergence_) | (max_divergence_ < 1e-9));
+                        orientation_offset_has_been_set_[axis] |= ((initial_delay_met_) &&
+                            ((abs_filter_difference < max_divergence_) | (max_divergence_ < 1e-9)));
 
                         // Handle the divergence test initialization
                         if(was_updating == false) {

--- a/src/ros_filter_bias_estimator.cpp
+++ b/src/ros_filter_bias_estimator.cpp
@@ -150,12 +150,13 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                         // Handle the initial delay - may be immediate if no delay set
                         initial_delay_met_ |= ((time_s - start_time_) > initial_delay_);
 
-                        // Calculate the difference between the two filters estimates
-                        double abs_filter_difference = ::fabs(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]);
+                        // Calculate the difference between the uncorrected filter estimate and the corrected magnetometer value
+                        double abs_filter_to_mag_difference = ::fabs(uncorrected_orientation_estimate_[axis] -
+                            (orientation_measurement[axis] + orientation_offset_[axis]));
 
                         // Dropped below limit or calculated once with no limit
                         orientation_offset_has_been_set_[axis] |= ((initial_delay_met_) &&
-                            ((abs_filter_difference < max_divergence_) | (max_divergence_ < 1e-9)));
+                            ((abs_filter_to_mag_difference < max_divergence_) | (max_divergence_ < 1e-9)));
 
                         // Handle the divergence test initialization
                         if(was_updating == false) {
@@ -165,16 +166,18 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                             // The calculation is from max_divergence_ = abs_filter_difference * alpha_^(divergence_test_steps_)
                             // divergence_test_steps_ = ln(max_divergence_ / abs_filter_difference) / ln(alpha_)
                             // Note that max_divergence_ must be < abs_filter_difference since alpha_ < 1.0
-                            if((max_divergence_ < abs_filter_difference) && (max_divergence_ > 0.0))
+                            double abs_filter_difference = ::fabs(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]);
+                            double max_difference = std::max(abs_filter_difference, abs_filter_to_mag_difference);
+                            if((max_divergence_ < max_difference) && (max_divergence_ > 0.0))
                             {
-                                divergence_test_steps_[axis] = round(log(max_divergence_ / abs_filter_difference) / log(alpha_));
+                                divergence_test_steps_[axis] = round(log(max_divergence_ / max_difference) / log(alpha_));
                             }
                             else
                             {
                                 divergence_test_steps_[axis] = 0;  // Already within tolerance
                             }
                             RF_TOOLS_VERBOSE("Required number of steps for axis " << axis_name <<
-                                " to test divergence: " << divergence_test_steps_[axis] << " given abs filter difference " << abs_filter_difference
+                                " to test divergence: " << divergence_test_steps_[axis] << " given abs difference " << max_difference
                                 << " and max difference " << max_divergence_ << "\n");
                             // Set the start counter
                             divergence_test_counter_[axis] = 0;


### PR DESCRIPTION
Two important changes occurred:
1) If data is rejected due to an external validity check, this now continues to not use the data until the estimates realign in order to avoid a jerk response when the data becomes valid again. This change also resulted in cleaning up the code for a more consistent look
2) An initial delay was added to ensure the estimates align before using magnetometer data. The reason is, with map reloading, the mower might immediately start driving autonomously without first running the perimeter, and thus their won't be enough time for the solution to converge.
Results of these changes shown in related robotic-lawnmower PR.

Lucas and Jonathan did a virtual review with me in which I walked the through the logic.