### PR TITLE
Adding GitHub Workflow

### DIFF
--- a/.github/workflows/debianize.yml
+++ b/.github/workflows/debianize.yml
@@ -1,0 +1,87 @@
+name: Build and Push
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Aptly server repository"
+        required: true
+        default: "experimental"
+        type: choice
+        options:
+          - stable
+          - rc
+          - experimental
+          - dependency
+  push:
+concurrency:
+  group: ${{ github.ref }}-build-push
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
+env:
+  SERVER_HOSTNAME: aptly.greenzie.com
+jobs:
+  debianize:
+    name: Build Debian
+    timeout-minutes: 60
+    runs-on:
+      - self-hosted
+      - greenzie
+    container:
+      image: greenzie/debianize:focal-noetic
+      credentials:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+      options: --cap-add=ALL
+    steps:
+      - name: Checkout Codebase
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          submodules: false
+      - name: Debianization
+        run: debianize
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: alldebs-${{ github.run_id }}
+          path: /debians/
+          retention-days: 1
+  deploy:
+    if: ${{ github.ref_name == 'noetic' || github.ref_name == 'noetic-devel' }}
+    name: Aptly Deploy
+    needs:
+      - debianize
+    timeout-minutes: 10
+    runs-on:
+      - self-hosted
+      - greenzie
+    container:
+      image: greenzie/aptly:3.15.5-focal-noetic
+      credentials:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+    steps:
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ env.SERVER_HOSTNAME }}
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: alldebs-${{ github.run_id }}
+          path: /debians
+      - name: Deploy Debians
+        working-directory: /debians
+        run: |
+          if [ -n "${{ inputs.repository }}" ] && [ "${{ github.ref_name }}" == "noetic" ]; then
+            aptly repo deploy --repo "${{ inputs.repository }}"
+          elif [ "${{ github.ref_name }}" == "noetic" ]; then
+            aptly repo deploy --repo rc
+          elif [ "${{ github.ref_name }}" == "noetic-devel" ]; then
+            aptly repo deploy --repo experimental
+          fi
+          
+          aptly repo deploy --repo dependency

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,60 @@ Source: ros-noetic-robot-localization
 Section: misc
 Priority: optional
 Maintainer: Tom Moore <ayrton04@gmail.com>
-Build-Depends: debhelper (>= 9.0.0), libeigen3-dev, libgeographic-dev, libyaml-cpp-dev, python3-catkin-pkg, ros-noetic-catkin, ros-noetic-cmake-modules, ros-noetic-diagnostic-msgs, ros-noetic-diagnostic-updater, ros-noetic-eigen-conversions, ros-noetic-geographic-msgs, ros-noetic-geometry-msgs, ros-noetic-message-filters, ros-noetic-message-generation, ros-noetic-nav-msgs, ros-noetic-nodelet, ros-noetic-rosbag, ros-noetic-roscpp, ros-noetic-roslint, ros-noetic-rostest, ros-noetic-rosunit, ros-noetic-sensor-msgs, ros-noetic-std-msgs, ros-noetic-std-srvs, ros-noetic-tf2, ros-noetic-tf2-geometry-msgs, ros-noetic-tf2-ros, ros-noetic-xmlrpcpp
+Build-Depends: debhelper (>= 9.0.0),
+    libeigen3-dev,
+	libgeographic-dev,
+	libyaml-cpp-dev,
+	python3-catkin-pkg,
+	ros-noetic-angles,
+	ros-noetic-catkin,
+	ros-noetic-cmake-modules,
+	ros-noetic-diagnostic-msgs,
+	ros-noetic-diagnostic-updater,
+	ros-noetic-eigen-conversions,
+	ros-noetic-geographic-msgs,
+	ros-noetic-geometry-msgs,
+	ros-noetic-message-filters,
+	ros-noetic-message-generation,
+	ros-noetic-nav-msgs,
+	ros-noetic-nodelet,
+	ros-noetic-rosbag <!nocheck>,
+	ros-noetic-roscpp,
+	ros-noetic-roslint,
+	ros-noetic-rostest <!nocheck>,
+	ros-noetic-rosunit <!nocheck>,
+	ros-noetic-sensor-msgs,
+	ros-noetic-std-msgs,
+	ros-noetic-std-srvs,
+	ros-noetic-tf2,
+	ros-noetic-tf2-geometry-msgs,
+	ros-noetic-tf2-ros
 Homepage: http://ros.org/wiki/robot_localization
 Standards-Version: 3.9.2
 
 Package: ros-noetic-robot-localization
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libeigen3-dev, libyaml-cpp-dev, ros-noetic-cmake-modules, ros-noetic-diagnostic-msgs, ros-noetic-diagnostic-updater, ros-noetic-eigen-conversions, ros-noetic-geographic-msgs, ros-noetic-geometry-msgs, ros-noetic-message-filters, ros-noetic-message-runtime, ros-noetic-nav-msgs, ros-noetic-nodelet, ros-noetic-roscpp, ros-noetic-sensor-msgs, ros-noetic-std-msgs, ros-noetic-std-srvs, ros-noetic-tf2, ros-noetic-tf2-geometry-msgs, ros-noetic-tf2-ros, ros-noetic-xmlrpcpp
+Depends: ${shlibs:Depends},
+    ${misc:Depends},
+    libeigen3-dev,
+	libgeographic-dev,
+	libyaml-cpp-dev,
+	ros-noetic-angles,
+	ros-noetic-cmake-modules,
+	ros-noetic-diagnostic-msgs,
+	ros-noetic-diagnostic-updater,
+	ros-noetic-eigen-conversions,
+	ros-noetic-geographic-msgs,
+	ros-noetic-geometry-msgs,
+	ros-noetic-message-filters,
+	ros-noetic-message-runtime,
+	ros-noetic-nav-msgs,
+	ros-noetic-nodelet,
+	ros-noetic-roscpp,
+	ros-noetic-sensor-msgs,
+	ros-noetic-std-msgs,
+	ros-noetic-std-srvs,
+	ros-noetic-tf2,
+	ros-noetic-tf2-geometry-msgs,
+	ros-noetic-tf2-ros
 Description: Provides nonlinear state estimation through sensor fusion of an abritrary number of sensors.


### PR DESCRIPTION
As discussed we are trying to speed up robotic-lawnmower builds
Current Process:
* Our Robotic Lawnmower workflow builds and pushes the following packages to aptly server:
  * hri-safe-remote-control-system
  * fix position tf and driver
  * robotic_localization

These projects have in common that they are submodules for robotic-lawnmower, we need them when compiling, however they are not updated as often.

Proposing to allow these forked projects to be build on their own workflows - This would save our robotic-lawnmower workflow about 5 minute of build time

New release proposal:
Whenever a change is done to these submodules:
* Change is pushed to `noetic-devel`, `development`, or similar branch... It pushes to `experimental` repo
* Change is pushed to `noetic`, `main`, `master`, or similar branch... it pushes to `rc` repo
* Whenever a change is required to be in production (`stable` repo)
  * A manual trigger is perform by selecting parameters:
    * Branch: `main`, `noetic`, `master`, or similar
    * Repo: `stable`

Doing this can help us decentralize our forks dependencis from the greenzie stack and also helps us focus on the greenzie-stack

This PR also fixes the `debian/control` to be in par with `packages.xml` -- `bloom-generate rosdebian`

Example how to trigger pipelines manually: 
![image](https://user-images.githubusercontent.com/30448358/197042616-afdc4f38-d018-4256-91a9-6aadfaa45d63.png)
