### PR TITLE
Handling trusted sensor inputs and bias compensation

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -110,7 +110,15 @@ struct CallbackData
 
 struct SourceData
 {
-  SourceData() {}
+  SourceData()
+  {
+    bias_pose_.resize(STATE_SIZE);
+    bias_pose_.setZero();
+    bias_twist_.resize(STATE_SIZE);
+    bias_twist_.setZero();
+    bias_acceleration_.resize(STATE_SIZE);
+    bias_acceleration_.setZero();
+  }
 
   bool trusted_{false};
   double last_trusted_s_{-99999.0};  // Never trusted initially

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -85,14 +85,16 @@ struct CallbackData
                const bool differential,
                const bool relative,
                const double rejectionThreshold,
-               const double rejectionThresholdInit) :
+               const double rejectionThresholdInit,
+               const double rejectionThresholdTrusted) :
     topicName_(topicName),
     updateVector_(updateVector),
     updateSum_(updateSum),
     differential_(differential),
     relative_(relative),
     rejectionThreshold_(rejectionThreshold),
-    rejectionThresholdInit_(rejectionThresholdInit)
+    rejectionThresholdInit_(rejectionThresholdInit),
+    rejectionThresholdTrusted_(rejectionThresholdTrusted)
   {
   }
 
@@ -103,6 +105,15 @@ struct CallbackData
   bool relative_;
   double rejectionThreshold_;
   double rejectionThresholdInit_;
+  double rejectionThresholdTrusted_;
+};
+
+struct SourceData
+{
+  SourceData() {}
+
+  bool trusted_{false};
+  double last_trusted_s_{-99999.0};  // Never trusted
 };
 
 typedef std::priority_queue<MeasurementPtr, std::vector<MeasurementPtr>, Measurement> MeasurementQueue;
@@ -241,6 +252,14 @@ template<class T> class RosFilter
     //! This method receives magnetometer validity information to associate with the dynamic correction data
     //!
     void imuMagnetometerValidityCallback(const std_msgs::Bool::ConstPtr &msg, const std::string &topicName);
+
+    //! @brief Callback method for receiving all trusted sensor data
+    //! @param[in] msg - The ROS Bool message to take in.
+    //! @param[in] topicName - The topic name for the sensor data that is trusted/untrusted
+    //!
+    //! This method receives trusted sensor information for handling rejection thresholds
+    //!
+    void trustedSensorCallback(const std_msgs::Bool::ConstPtr &msg, const std::string &topicName);
 
     //! @brief Processes all measurements in the measurement queue, in temporal order
     //!
@@ -522,6 +541,10 @@ template<class T> class RosFilter
     //!
     double frequency_;
 
+    //! @brief Timeout for trusted rejection threshold (< 0 for infinite)
+    //!
+    double trusted_timeout_;
+
     //! @brief What is the acceleration in Z due to gravity (m/s^2)? Default is +9.80665.
     //!
     double gravitationalAcc_;
@@ -628,9 +651,13 @@ template<class T> class RosFilter
     //!
     std::map<std::string, std::string> staticDiagnostics_;
 
-    //! @brief Thisobject holds dynamic correction information, if enabled, per IMU input
+    //! @brief This object holds dynamic correction information, if enabled, per IMU input
     //!
     std::map<std::string, RosFilterBiasEstimator> imuDynamicCorrectionData_;
+
+    //! @brief Holds information about data sources
+    //!
+    std::map<std::string, SourceData> sourceData_;
 
     //! @brief The most recent control input
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -121,12 +121,12 @@ struct SourceData
   }
 
   bool trusted_{false};
-  double last_trusted_s_{-99999.0};  // Never trusted initially
+  double last_trusted_s_{-std::numeric_limits<double>::infinity()};  // Never trusted initially
   Eigen::VectorXd bias_pose_;
   Eigen::VectorXd bias_twist_;
   Eigen::VectorXd bias_acceleration_;
   bool bias_valid_{false};  // Invalid initially
-  double last_bias_s_{-99999.0};  // Never set initially
+  double last_bias_s_{-std::numeric_limits<double>::infinity()};  // Never set initially
 };
 
 typedef std::priority_queue<MeasurementPtr, std::vector<MeasurementPtr>, Measurement> MeasurementQueue;
@@ -350,8 +350,10 @@ template<class T> class RosFilter
     //! This method simply separates out the pose and twist data into two new messages, and passes them into their
     //! respective callbacks
     //!
-    void biasOdometryCallback(const nav_msgs::Odometry::ConstPtr &msg, const std::string &topicName,
-      const CallbackData &poseCallbackData, const CallbackData &twistCallbackData);
+    void biasOdometryCallback(const nav_msgs::Odometry::ConstPtr &msg,
+                              const std::string &topicName,
+                              const CallbackData &poseCallbackData,
+                              const CallbackData &twistCallbackData);
 
     //! @brief Callback method for receiving bias IMU messages
     //! @param[in] msg - The ROS IMU message to take in.
@@ -363,9 +365,11 @@ template<class T> class RosFilter
     //! This method separates out the orientation, angular velocity, and linear acceleration data and
     //! passed each on to its respective callback.
     //!
-    void biasImuCallback(const sensor_msgs::Imu::ConstPtr &msg, const std::string &topicName,
-      const CallbackData &poseCallbackData, const CallbackData &twistCallbackData,
-      const CallbackData &accelCallbackData);
+    void biasImuCallback(const sensor_msgs::Imu::ConstPtr &msg,
+                         const std::string &topicName,
+                         const CallbackData &poseCallbackData,
+                         const CallbackData &twistCallbackData,
+                         const CallbackData &accelCallbackData);
   
     //! @brief Callback method for receiving bias pose messages
     //! @param[in] msg - The ROS stamped pose with covariance message to take in
@@ -374,9 +378,9 @@ template<class T> class RosFilter
     //! @param[in] imuData - Whether this data comes from an IMU
     //!
     void biasPoseCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr &msg,
-                      const CallbackData &callbackData,
-                      const std::string &targetFrame,
-                      const bool imuData);
+                          const CallbackData &callbackData,
+                          const std::string &targetFrame,
+                          const bool imuData);
     
     //! @brief Callback method for receiving bias twist messages
     //! @param[in] msg - The ROS stamped twist with covariance message to take in.

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -113,7 +113,12 @@ struct SourceData
   SourceData() {}
 
   bool trusted_{false};
-  double last_trusted_s_{-99999.0};  // Never trusted
+  double last_trusted_s_{-99999.0};  // Never trusted initially
+  Eigen::VectorXd bias_pose_;
+  Eigen::VectorXd bias_twist_;
+  Eigen::VectorXd bias_acceleration_;
+  bool bias_valid_{false};  // Invalid initially
+  double last_bias_s_{-99999.0};  // Never set initially
 };
 
 typedef std::priority_queue<MeasurementPtr, std::vector<MeasurementPtr>, Measurement> MeasurementQueue;
@@ -328,6 +333,61 @@ template<class T> class RosFilter
     //!
     bool validateFilterOutput(const nav_msgs::Odometry &message);
 
+    //! @brief Callback method for receiving bias odometry messages
+    //! @param[in] msg - The ROS odometry message to take in.
+    //! @param[in] topicName - The topic name for the odometry message (only used for debug output)
+    //! @param[in] poseCallbackData - Relevant static callback data for pose variables
+    //! @param[in] twistCallbackData - Relevant static callback data for twist variables
+    //!
+    //! This method simply separates out the pose and twist data into two new messages, and passes them into their
+    //! respective callbacks
+    //!
+    void biasOdometryCallback(const nav_msgs::Odometry::ConstPtr &msg, const std::string &topicName,
+      const CallbackData &poseCallbackData, const CallbackData &twistCallbackData);
+
+    //! @brief Callback method for receiving bias IMU messages
+    //! @param[in] msg - The ROS IMU message to take in.
+    //! @param[in] topicName - The topic name for the IMU message (used to store data)
+    //! @param[in] poseCallbackData - Relevant static callback data for orientation variables
+    //! @param[in] twistCallbackData - Relevant static callback data for angular velocity variables
+    //! @param[in] accelCallbackData - Relevant static callback data for linear acceleration variables
+    //!
+    //! This method separates out the orientation, angular velocity, and linear acceleration data and
+    //! passed each on to its respective callback.
+    //!
+    void biasImuCallback(const sensor_msgs::Imu::ConstPtr &msg, const std::string &topicName,
+      const CallbackData &poseCallbackData, const CallbackData &twistCallbackData,
+      const CallbackData &accelCallbackData);
+  
+    //! @brief Callback method for receiving bias pose messages
+    //! @param[in] msg - The ROS stamped pose with covariance message to take in
+    //! @param[in] callbackData - Relevant static callback data
+    //! @param[in] targetFrame - The target frame_id into which to transform the data
+    //! @param[in] imuData - Whether this data comes from an IMU
+    //!
+    void biasPoseCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr &msg,
+                      const CallbackData &callbackData,
+                      const std::string &targetFrame,
+                      const bool imuData);
+    
+    //! @brief Callback method for receiving bias twist messages
+    //! @param[in] msg - The ROS stamped twist with covariance message to take in.
+    //! @param[in] callbackData - Relevant static callback data
+    //! @param[in] targetFrame - The target frame_id into which to transform the data
+    //!
+    void biasTwistCallback(const geometry_msgs::TwistWithCovarianceStamped::ConstPtr &msg,
+                           const CallbackData &callbackData,
+                           const std::string &targetFrame);
+
+    //! @brief Callback method for receiving bias acceleration (IMU) messages
+    //! @param[in] msg - The ROS IMU message to take in.
+    //! @param[in] callbackData - Relevant static callback data
+    //! @param[in] targetFrame - The target frame_id into which to transform the data
+    //!
+    void biasAccelerationCallback(const sensor_msgs::Imu::ConstPtr &msg,
+                                  const CallbackData &callbackData,
+                                  const std::string &targetFrame);
+
   protected:
     //! @brief Finds the latest filter state before the given timestamp and makes it the current state again.
     //!
@@ -411,6 +471,7 @@ template<class T> class RosFilter
     //! @param[in] msg - The IMU message to prepare
     //! @param[in] topicName - The name of the topic over which this message was received
     //! @param[in] targetFrame - The target tf frame
+    //! @param[in] removeGraviationalAccel - whether to remove gravitational acceleration
     //! @param[in] updateVector - The update vector for the data source
     //! @param[in] measurement - The twist data converted to a measurement
     //! @param[in] measurementCovariance - The covariance of the converted measurement
@@ -418,6 +479,7 @@ template<class T> class RosFilter
     bool prepareAcceleration(const sensor_msgs::Imu::ConstPtr &msg,
                              const std::string &topicName,
                              const std::string &targetFrame,
+                             const bool &removeGravitationalAccel,
                              std::vector<int> &updateVector,
                              Eigen::VectorXd &measurement,
                              Eigen::MatrixXd &measurementCovariance);
@@ -544,6 +606,10 @@ template<class T> class RosFilter
     //! @brief Timeout for trusted rejection threshold (< 0 for infinite)
     //!
     double trusted_timeout_;
+
+    //! @brief Timeout for bias information (<0 for infinite)
+    //!
+    double bias_timeout_;
 
     //! @brief What is the acceleration in Z due to gravity (m/s^2)? Default is +9.80665.
     //!

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1148,6 +1148,10 @@ namespace RobotLocalization
         nhLocal_.param(odomTopicName + std::string("_pose_rejection_threshold_initialize"),
                        poseMahalanobisThreshInit,
                        std::numeric_limits<double>::max());
+        double poseMahalanobisThreshTrusted;
+        nhLocal_.param(odomTopicName + std::string("_pose_rejection_threshold_trusted"),
+                       poseMahalanobisThreshTrusted,
+                       std::numeric_limits<double>::max());
 
         // Check for twist rejection threshold
         double twistMahalanobisThresh;
@@ -1157,6 +1161,10 @@ namespace RobotLocalization
         double twistMahalanobisThreshInit;
         nhLocal_.param(odomTopicName + std::string("_twist_rejection_threshold_initialize"),
                        twistMahalanobisThreshInit,
+                       std::numeric_limits<double>::max());
+        double twistMahalanobisThreshTrusted;
+        nhLocal_.param(odomTopicName + std::string("_twist_rejection_threshold_trusted"),
+                       twistMahalanobisThreshTrusted,
                        std::numeric_limits<double>::max());
 
         // Now pull in its boolean update vector configuration. Create separate vectors for pose
@@ -1282,6 +1290,10 @@ namespace RobotLocalization
         nhLocal_.param(poseTopicName + std::string("_rejection_threshold_initialize"),
                        poseMahalanobisThreshInit,
                        std::numeric_limits<double>::max());
+        double poseMahalanobisThreshTrusted;
+        nhLocal_.param(poseTopicName + std::string("_rejection_threshold_trusted"),
+                       poseMahalanobisThreshTrusted,
+                       std::numeric_limits<double>::max());
 
         int poseQueueSize = 1;
         nhLocal_.param(poseTopicName + "_queue_size", poseQueueSize, 1);
@@ -1368,6 +1380,10 @@ namespace RobotLocalization
         nhLocal_.param(twistTopicName + std::string("_rejection_threshold_initialize"),
                        twistMahalanobisThreshInit,
                        std::numeric_limits<double>::max());
+        double twistMahalanobisThreshTrusted;
+        nhLocal_.param(twistTopicName + std::string("_rejection_threshold_trusted"),
+                       twistMahalanobisThreshTrusted,
+                       std::numeric_limits<double>::max());
 
         int twistQueueSize = 1;
         nhLocal_.param(twistTopicName + "_queue_size", twistQueueSize, 1);
@@ -1451,6 +1467,10 @@ namespace RobotLocalization
         nhLocal_.param(imuTopicName + std::string("_pose_rejection_threshold_initialize"),
                        poseMahalanobisThreshInit,
                        std::numeric_limits<double>::max());
+        double poseMahalanobisThreshTrusted;
+        nhLocal_.param(imuTopicName + std::string("_pose_rejection_threshold_trusted"),
+                       poseMahalanobisThreshTrusted,
+                       std::numeric_limits<double>::max());
 
         // Check for angular velocity rejection threshold
         double twistMahalanobisThresh;
@@ -1461,6 +1481,10 @@ namespace RobotLocalization
         imuTwistRejectionName =
           imuTopicName + std::string("_twist_rejection_threshold_initialize");
         nhLocal_.param(imuTwistRejectionName, twistMahalanobisThreshInit, std::numeric_limits<double>::max());
+        double twistMahalanobisThreshTrusted;
+        imuTwistRejectionName =
+          imuTopicName + std::string("_twist_rejection_threshold_trusted");
+        nhLocal_.param(imuTwistRejectionName, twistMahalanobisThreshTrusted, std::numeric_limits<double>::max());
 
         // Check for acceleration rejection threshold
         double accelMahalanobisThresh;
@@ -1470,6 +1494,10 @@ namespace RobotLocalization
         double accelMahalanobisThreshInit;
         nhLocal_.param(imuTopicName + std::string("_linear_acceleration_rejection_threshold_initialize"),
                        accelMahalanobisThreshInit,
+                       std::numeric_limits<double>::max());
+        double accelMahalanobisThreshTrusted;
+        nhLocal_.param(imuTopicName + std::string("_linear_acceleration_rejection_threshold_trusted"),
+                       accelMahalanobisThreshTrusted,
                        std::numeric_limits<double>::max());
 
         bool removeGravAcc = false;

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1422,8 +1422,8 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << poseTopic << " (" << poseTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << poseTopic << "/trusted" << " (" << poseTopicName << ")\n\t" <<
-                 "subscribed to bias source " << poseTopic << "/bias" << " (" << poseTopicName << ")\n\t" <<
+                 "Subscribed to trusting source " << poseTopic << "/trusted" << " (" << poseTopicName << ")\n\t" <<
+                 "Subscribed to bias source " << poseTopic << "/bias" << " (" << poseTopicName << ")\n\t" <<
                  poseTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  poseTopicName << "_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
                  poseTopicName << "_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1296,8 +1296,8 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << odomTopic << " (" << odomTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << odomTopic << "/trusted" << " (" << odomTopicName << ")\n\t" <<
-                 "subscribed to bias source " << odomTopic << "/bias" << " (" << odomTopicName << ")\n\t" <<
+                 "Subscribed to trusting source " << odomTopic << "/trusted" << " (" << odomTopicName << ")\n\t" <<
+                 "Subscribed to bias source " << odomTopic << "/bias" << " (" << odomTopicName << ")\n\t" <<
                  odomTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  odomTopicName << "_pose_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
                  odomTopicName << "_pose_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1805,8 +1805,8 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << imuTopic << " (" << imuTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << imuTopic << "/trusted" << " (" << imuTopicName << ")\n\t" <<
-                 "subscribed to bias source " << imuTopic << "/bias" << " (" << imuTopicName << ")\n\t" <<
+                 "Subscribed to trusting source " << imuTopic << "/trusted" << " (" << imuTopicName << ")\n\t" <<
+                 "Subscribed to bias source " << imuTopic << "/bias" << " (" << imuTopicName << ")\n\t" <<
                  imuTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  imuTopicName << "_pose_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
                  imuTopicName << "_pose_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1512,8 +1512,8 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << twistTopic << " (" << twistTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << twistTopic << "/trusted" << " (" << twistTopicName << ")\n\t" <<
-                 "subscribed to bias source " << twistTopic << "/bias" << " (" << twistTopicName << ")\n\t" <<
+                 "Subscribed to trusting source " << twistTopic << "/trusted" << " (" << twistTopicName << ")\n\t" <<
+                 "Subscribed to bias source " << twistTopic << "/bias" << " (" << twistTopicName << ")\n\t" <<
                  twistTopicName << "_rejection_threshold is " << twistMahalanobisThresh << "\n\t" <<
                  twistTopicName << "_rejection_threshold_init is " << twistMahalanobisThreshInit << "\n\t" <<
                  twistTopicName << "_rejection_threshold_trusted is " << twistMahalanobisThreshTrusted << "\n\t" <<

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -72,6 +72,7 @@ namespace RobotLocalization
       dynamicDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
       staticDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
       frequency_(30.0),
+      trusted_timeout_{-1.0},
       gravitationalAcc_(9.80665),
       historyLength_(0),
       minFrequency_(frequency_ - 2.0),
@@ -251,13 +252,20 @@ namespace RobotLocalization
       if (prepareAcceleration(msg, topicName, targetFrame, updateVectorCorrected, measurement,
             measurementCovariance))
       {
+        // Check which rejection threshold to use
+        double rejectionThreshold = callbackData.rejectionThreshold_;
+        if((sourceData_.find(topicName) != sourceData_.end() &&
+          (sourceData_[topicName].trusted_)))
+        {
+          rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+        }
         // Store the measurement. Add an "acceleration" suffix so we know what kind of measurement
         // we're dealing with when we debug the core filter logic.
         enqueueMeasurement(topicName,
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
-                           callbackData.rejectionThreshold_,
+                           rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
 
@@ -638,6 +646,26 @@ namespace RobotLocalization
   }
 
   template<typename T>
+  void RosFilter<T>::trustedSensorCallback(const std_msgs::Bool::ConstPtr &msg,
+                                           const std::string &topicName)
+  {
+    // RF_VERBOSE provides this info in the debug file inline with the received and
+    //  and processed data, so is highly useful
+    RF_VERBOSE("Received trusted sensor data for topic " << topicName <<
+      " with trusted " << ((msg->data) ? "true\n" : "false\n"));
+    // If this information is to be provided via a ROS stream, do so from the provider
+    // Pass it in/save it all
+    if(sourceData_.find(topicName) == sourceData_.end())
+    {
+      // Create it
+      sourceData_.emplace(topicName, SourceData());
+    }
+    // Save the data
+    sourceData_[topicName].trusted_ = msg->data;
+    sourceData_[topicName].last_trusted_s_ = ros::Time::now().toSec();
+  }
+
+  template<typename T>
   void RosFilter<T>::integrateMeasurements(const ros::Time &currentTime)
   {
     const double currentTimeSec = currentTime.toSec();
@@ -914,6 +942,8 @@ namespace RobotLocalization
     nhLocal_.param("sensor_timeout", sensorTimeout, 1.0 / frequency_);
     filter_.setSensorTimeout(sensorTimeout);
 
+    nhLocal_.param("trusted_timeout", trusted_timeout_, -1.0);
+
     // Determine if we're in 2D mode
     nhLocal_.param("two_d_mode", twoDMode_, false);
 
@@ -1182,9 +1212,9 @@ namespace RobotLocalization
         nhLocal_.param(odomTopicName + "_queue_size", odomQueueSize, 1);
 
         const CallbackData poseCallbackData(odomTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
-          relative, poseMahalanobisThresh, poseMahalanobisThreshInit);
+          relative, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
         const CallbackData twistCallbackData(odomTopicName + "_twist", twistUpdateVec, twistUpdateSum, false, false,
-          twistMahalanobisThresh, twistMahalanobisThresh);
+          twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
 
         bool nodelayOdom = false;
         nhLocal_.param(odomTopicName + "_nodelay", nodelayOdom, false);
@@ -1196,6 +1226,18 @@ namespace RobotLocalization
             nh_.subscribe<nav_msgs::Odometry>(odomTopic, odomQueueSize,
               boost::bind(&RosFilter::odometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData),
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayOdom)));
+          
+          // Subscribe to trusted data as well
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(odomTopic + std::string("/trusted/pose"), odomQueueSize,
+              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
+                odomTopicName + "_pose"), ros::VoidPtr(),
+                ros::TransportHints().tcpNoDelay(nodelayOdom)));
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(odomTopic + std::string("/trusted/twist"), odomQueueSize,
+              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
+                odomTopicName + "_twist"), ros::VoidPtr(),
+                ros::TransportHints().tcpNoDelay(nodelayOdom)));
         }
         else
         {
@@ -1241,9 +1283,15 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << odomTopic << " (" << odomTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << odomTopic << "/trusted/pose" << " (" << odomTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << odomTopic << "/trusted/twist" << " (" << odomTopicName << ")\n\t" <<
                  odomTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  odomTopicName << "_pose_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
+                 odomTopicName << "_pose_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<
+                 odomTopicName << "_pose_rejection_threshold_trusted is " << poseMahalanobisThreshTrusted << "\n\t" <<
                  odomTopicName << "_twist_rejection_threshold is " << twistMahalanobisThresh << "\n\t" <<
+                 odomTopicName << "_twist_rejection_threshold_init is " << twistMahalanobisThreshInit << "\n\t" <<
+                 odomTopicName << "_twist_rejection_threshold_trusted is " << twistMahalanobisThreshTrusted << "\n\t" <<
                  odomTopicName << "_queue_size is " << odomQueueSize << "\n\t" <<
                  odomTopicName << " pose update vector is " << poseUpdateVec << "\t"<<
                  odomTopicName << " twist update vector is " << twistUpdateVec);
@@ -1315,12 +1363,19 @@ namespace RobotLocalization
         if (poseUpdateSum > 0)
         {
           const CallbackData callbackData(poseTopicName, poseUpdateVec, poseUpdateSum, differential, relative,
-            poseMahalanobisThresh, poseMahalanobisThreshInit);
+            poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(poseTopic, poseQueueSize,
               boost::bind(&RosFilter::poseCallback, this, _1, callbackData, worldFrameId_, false),
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayPose)));
+          
+          // Subscribe to trusted data as well
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(poseTopic + std::string("/trusted/pose"), poseQueueSize,
+              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
+                poseTopic), ros::VoidPtr(),
+                ros::TransportHints().tcpNoDelay(nodelayPose)));
 
           if (differential)
           {
@@ -1348,8 +1403,11 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << poseTopic << " (" << poseTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << poseTopic << "/trusted/pose" << " (" << poseTopicName << ")\n\t" <<
                  poseTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  poseTopicName << "_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
+                 poseTopicName << "_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<
+                 poseTopicName << "_rejection_threshold_trusted is " << poseMahalanobisThreshTrusted << "\n\t" <<
                  poseTopicName << "_queue_size is " << poseQueueSize << "\n\t" <<
                  poseTopicName << " update vector is " << poseUpdateVec);
       }
@@ -1400,12 +1458,19 @@ namespace RobotLocalization
         if (twistUpdateSum > 0)
         {
           const CallbackData callbackData(twistTopicName, twistUpdateVec, twistUpdateSum, false, false,
-            twistMahalanobisThresh, twistMahalanobisThreshInit);
+            twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(twistTopic, twistQueueSize,
               boost::bind(&RosFilter<T>::twistCallback, this, _1, callbackData, baseLinkFrameId_),
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayTwist)));
+          
+          // Subscribe to trusted data as well
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(twistTopic + std::string("/trusted/twist"), twistQueueSize,
+              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
+                twistTopic), ros::VoidPtr(),
+                ros::TransportHints().tcpNoDelay(nodelayTwist)));
 
           twistVarCounts[StateMemberVx] += twistUpdateVec[StateMemberVx];
           twistVarCounts[StateMemberVy] += twistUpdateVec[StateMemberVy];
@@ -1421,7 +1486,10 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << twistTopic << " (" << twistTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << twistTopic << "/trusted/twist" << " (" << twistTopicName << ")\n\t" <<
                  twistTopicName << "_rejection_threshold is " << twistMahalanobisThresh << "\n\t" <<
+                 twistTopicName << "_rejection_threshold_init is " << twistMahalanobisThreshInit << "\n\t" <<
+                 twistTopicName << "_rejection_threshold_trusted is " << twistMahalanobisThreshTrusted << "\n\t" <<
                  twistTopicName << "_queue_size is " << twistQueueSize << "\n\t" <<
                  twistTopicName << " update vector is " << twistUpdateVec);
       }
@@ -1590,16 +1658,33 @@ namespace RobotLocalization
         if (poseUpdateSum + twistUpdateSum + accelUpdateSum > 0)
         {
           const CallbackData poseCallbackData(imuTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
-            relative, poseMahalanobisThresh, poseMahalanobisThreshInit);
+            relative, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
           const CallbackData twistCallbackData(imuTopicName + "_twist", twistUpdateVec, twistUpdateSum, differential,
-            relative, twistMahalanobisThresh, twistMahalanobisThreshInit);
+            relative, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
           const CallbackData accelCallbackData(imuTopicName + "_acceleration", accelUpdateVec, accelUpdateSum,
-            differential, relative, accelMahalanobisThresh, accelMahalanobisThreshInit);
+            differential, relative, accelMahalanobisThresh, accelMahalanobisThreshInit, accelMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<sensor_msgs::Imu>(imuTopic, imuQueueSize,
               boost::bind(&RosFilter<T>::imuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
                 accelCallbackData), ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayImu)));
+          
+          // Subscribe to trusted data as well
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(imuTopic + std::string("/trusted/pose"), imuQueueSize,
+              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
+                imuTopic + "_pose"), ros::VoidPtr(),
+                ros::TransportHints().tcpNoDelay(nodelayImu)));
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(imuTopic + std::string("/trusted/twist"), imuQueueSize,
+              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
+                imuTopic + "_twist"), ros::VoidPtr(),
+                ros::TransportHints().tcpNoDelay(nodelayImu)));
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(imuTopic + std::string("/trusted/acceleration"), imuQueueSize,
+              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
+                imuTopic + "_acceleration"), ros::VoidPtr(),
+                ros::TransportHints().tcpNoDelay(nodelayImu)));
         }
         else
         {
@@ -1697,10 +1782,19 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << imuTopic << " (" << imuTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << imuTopic << "/trusted/pose" << " (" << imuTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << imuTopic << "/trusted/twist" << " (" << imuTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << imuTopic << "/trusted/acceleration" << " (" << imuTopicName << ")\n\t" <<
                  imuTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  imuTopicName << "_pose_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
+                 imuTopicName << "_pose_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<
+                 imuTopicName << "_pose_rejection_threshold_trusted is " << poseMahalanobisThreshTrusted << "\n\t" <<
                  imuTopicName << "_twist_rejection_threshold is " << twistMahalanobisThresh << "\n\t" <<
+                 imuTopicName << "_twist_rejection_thresholdInit is " << twistMahalanobisThreshInit << "\n\t" <<
+                 imuTopicName << "_twist_rejection_thresholdTrusted is " << twistMahalanobisThreshTrusted << "\n\t" <<
                  imuTopicName << "_linear_acceleration_rejection_threshold is " << accelMahalanobisThresh << "\n\t" <<
+                 imuTopicName << "_linear_acceleration_rejection_threshold_init is " << accelMahalanobisThreshInit << "\n\t" <<
+                 imuTopicName << "_linear_acceleration_rejection_threshold_trusted is " << accelMahalanobisThreshTrusted << "\n\t" <<
                  imuTopicName << "_remove_gravitational_acceleration is " <<
                                  (removeGravAcc ? "true" : "false") << "\n\t" <<
                  imuTopicName << "_queue_size is " << imuQueueSize << "\n\t" <<
@@ -2009,13 +2103,21 @@ namespace RobotLocalization
                       measurement,
                       measurementCovariance))
       {
+        // Check which rejection threshold to use
+        double rejectionThreshold = callbackData.rejectionThreshold_;
+        if((sourceData_.find(topicName) != sourceData_.end() &&
+          (sourceData_[topicName].trusted_)))
+        {
+          rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+        }
         // Store the measurement. Add a "pose" suffix so we know what kind of measurement
         // we're dealing with when we debug the core filter logic.
+        // TODO: Determine if measurement is trusted and set mahalanobis distance accordingly
         enqueueMeasurement(topicName,
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
-                           callbackData.rejectionThreshold_,
+                           rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
 
@@ -2073,6 +2175,20 @@ namespace RobotLocalization
     }
 
     ros::Time curTime = ros::Time::now();
+    double secCurTime = curTime.toSec();
+
+    // Handle any timeouts of trusted data
+    if(trusted_timeout_ > 0.0)
+    {
+      for(auto &item : sourceData_)
+      {
+        if((item.second.trusted_ == true) && (secCurTime > (item.second.last_trusted_s_ + trusted_timeout_)))
+        {
+          // Trusted status timed out
+          item.second.trusted_ = false;
+        }
+      }
+    }
 
     if (toggledOn_)
     {
@@ -2364,13 +2480,20 @@ namespace RobotLocalization
       // Prepare the twist data for inclusion in the filter
       if (prepareTwist(msg, topicName, targetFrame, updateVectorCorrected, measurement, measurementCovariance))
       {
+        // Check which rejection threshold to use
+        double rejectionThreshold = callbackData.rejectionThreshold_;
+        if((sourceData_.find(topicName) != sourceData_.end() &&
+          (sourceData_[topicName].trusted_)))
+        {
+          rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+        }
         // Store the measurement. Add a "twist" suffix so we know what kind of measurement
         // we're dealing with when we debug the core filter logic.
         enqueueMeasurement(topicName,
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
-                           callbackData.rejectionThreshold_,
+                           rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -73,6 +73,7 @@ namespace RobotLocalization
       staticDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
       frequency_(30.0),
       trusted_timeout_{-1.0},
+      bias_timeout_{-1.0},
       gravitationalAcc_(9.80665),
       historyLength_(0),
       minFrequency_(frequency_ - 2.0),
@@ -249,15 +250,24 @@ namespace RobotLocalization
       std::vector<int> updateVectorCorrected = callbackData.updateVector_;
 
       // Prepare the twist data for inclusion in the filter
-      if (prepareAcceleration(msg, topicName, targetFrame, updateVectorCorrected, measurement,
+      if (prepareAcceleration(msg, topicName, targetFrame, removeGravitationalAcc_[topicName], updateVectorCorrected, measurement,
             measurementCovariance))
       {
-        // Check which rejection threshold to use
+        // Check which rejection threshold to use and whether to use bias information
         double rejectionThreshold = callbackData.rejectionThreshold_;
-        if((sourceData_.find(topicName) != sourceData_.end() &&
-          (sourceData_[topicName].trusted_)))
+        if(sourceData_.find(topicName) != sourceData_.end())
         {
-          rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+          RF_VERBOSE("Has source data for topic " << topicName << " acceleration\n");
+          if(sourceData_[topicName].trusted_)
+          {
+            // Trusted source
+            rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+          }
+          if(sourceData_[topicName].bias_valid_)
+          {
+            // Use bias information
+            measurement += sourceData_[topicName].bias_acceleration_;
+          }
         }
         // Store the measurement. Add an "acceleration" suffix so we know what kind of measurement
         // we're dealing with when we debug the core filter logic.
@@ -657,6 +667,7 @@ namespace RobotLocalization
     // Pass it in/save it all
     if(sourceData_.find(topicName) == sourceData_.end())
     {
+      RF_VERBOSE("Adding trusted sensor source data for topic " << topicName << "\n");
       // Create it
       sourceData_.emplace(topicName, SourceData());
     }
@@ -943,6 +954,7 @@ namespace RobotLocalization
     filter_.setSensorTimeout(sensorTimeout);
 
     nhLocal_.param("trusted_timeout", trusted_timeout_, -1.0);
+    nhLocal_.param("bias_timeout", bias_timeout_, -1.0);
 
     // Determine if we're in 2D mode
     nhLocal_.param("two_d_mode", twoDMode_, false);
@@ -1226,17 +1238,18 @@ namespace RobotLocalization
             nh_.subscribe<nav_msgs::Odometry>(odomTopic, odomQueueSize,
               boost::bind(&RosFilter::odometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData),
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayOdom)));
+
+          // Subscribe to bias data
+          topicSubs_.push_back(
+            nh_.subscribe<nav_msgs::Odometry>(odomTopic + std::string("/bias"), odomQueueSize,
+              boost::bind(&RosFilter::biasOdometryCallback, this, _1, odomTopicName, poseCallbackData, twistCallbackData),
+              ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayOdom)));
           
-          // Subscribe to trusted data as well
+          // Subscribe to trusted data
           topicSubs_.push_back(
-            nh_.subscribe<std_msgs::Bool>(odomTopic + std::string("/trusted/pose"), odomQueueSize,
+            nh_.subscribe<std_msgs::Bool>(odomTopic + std::string("/trusted"), odomQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                odomTopicName + "_pose"), ros::VoidPtr(),
-                ros::TransportHints().tcpNoDelay(nodelayOdom)));
-          topicSubs_.push_back(
-            nh_.subscribe<std_msgs::Bool>(odomTopic + std::string("/trusted/twist"), odomQueueSize,
-              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                odomTopicName + "_twist"), ros::VoidPtr(),
+                odomTopicName), ros::VoidPtr(),
                 ros::TransportHints().tcpNoDelay(nodelayOdom)));
         }
         else
@@ -1283,8 +1296,8 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << odomTopic << " (" << odomTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << odomTopic << "/trusted/pose" << " (" << odomTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << odomTopic << "/trusted/twist" << " (" << odomTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << odomTopic << "/trusted" << " (" << odomTopicName << ")\n\t" <<
+                 "subscribed to bias source " << odomTopic << "/bias" << " (" << odomTopicName << ")\n\t" <<
                  odomTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  odomTopicName << "_pose_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
                  odomTopicName << "_pose_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<
@@ -1370,9 +1383,15 @@ namespace RobotLocalization
               boost::bind(&RosFilter::poseCallback, this, _1, callbackData, worldFrameId_, false),
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayPose)));
           
-          // Subscribe to trusted data as well
+          // Subscribe to bias data
           topicSubs_.push_back(
-            nh_.subscribe<std_msgs::Bool>(poseTopic + std::string("/trusted/pose"), poseQueueSize,
+            nh_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(poseTopic + std::string("/bias"), poseQueueSize,
+              boost::bind(&RosFilter::biasPoseCallback, this, _1, callbackData, worldFrameId_, false),
+              ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayPose)));
+          
+          // Subscribe to trusted data
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(poseTopic + std::string("/trusted"), poseQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
                 poseTopic), ros::VoidPtr(),
                 ros::TransportHints().tcpNoDelay(nodelayPose)));
@@ -1403,7 +1422,8 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << poseTopic << " (" << poseTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << poseTopic << "/trusted/pose" << " (" << poseTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << poseTopic << "/trusted" << " (" << poseTopicName << ")\n\t" <<
+                 "subscribed to bias source " << poseTopic << "/bias" << " (" << poseTopicName << ")\n\t" <<
                  poseTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  poseTopicName << "_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
                  poseTopicName << "_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<
@@ -1465,9 +1485,15 @@ namespace RobotLocalization
               boost::bind(&RosFilter<T>::twistCallback, this, _1, callbackData, baseLinkFrameId_),
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayTwist)));
           
-          // Subscribe to trusted data as well
+          // Subscribe to bias data
           topicSubs_.push_back(
-            nh_.subscribe<std_msgs::Bool>(twistTopic + std::string("/trusted/twist"), twistQueueSize,
+            nh_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(twistTopic + std::string("/bias"), twistQueueSize,
+              boost::bind(&RosFilter<T>::biasTwistCallback, this, _1, callbackData, baseLinkFrameId_),
+              ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayTwist)));
+
+          // Subscribe to trusted data
+          topicSubs_.push_back(
+            nh_.subscribe<std_msgs::Bool>(twistTopic + std::string("/trusted"), twistQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
                 twistTopic), ros::VoidPtr(),
                 ros::TransportHints().tcpNoDelay(nodelayTwist)));
@@ -1486,7 +1512,8 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << twistTopic << " (" << twistTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << twistTopic << "/trusted/twist" << " (" << twistTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << twistTopic << "/trusted" << " (" << twistTopicName << ")\n\t" <<
+                 "subscribed to bias source " << twistTopic << "/bias" << " (" << twistTopicName << ")\n\t" <<
                  twistTopicName << "_rejection_threshold is " << twistMahalanobisThresh << "\n\t" <<
                  twistTopicName << "_rejection_threshold_init is " << twistMahalanobisThreshInit << "\n\t" <<
                  twistTopicName << "_rejection_threshold_trusted is " << twistMahalanobisThreshTrusted << "\n\t" <<
@@ -1669,21 +1696,17 @@ namespace RobotLocalization
               boost::bind(&RosFilter<T>::imuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
                 accelCallbackData), ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayImu)));
           
-          // Subscribe to trusted data as well
+          // Subscribe to bias data
           topicSubs_.push_back(
-            nh_.subscribe<std_msgs::Bool>(imuTopic + std::string("/trusted/pose"), imuQueueSize,
-              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                imuTopic + "_pose"), ros::VoidPtr(),
-                ros::TransportHints().tcpNoDelay(nodelayImu)));
+            nh_.subscribe<sensor_msgs::Imu>(imuTopic + std::string("/bias"), imuQueueSize,
+              boost::bind(&RosFilter<T>::biasImuCallback, this, _1, imuTopicName, poseCallbackData, twistCallbackData,
+                accelCallbackData), ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayImu)));
+
+          // Subscribe to trusted data
           topicSubs_.push_back(
-            nh_.subscribe<std_msgs::Bool>(imuTopic + std::string("/trusted/twist"), imuQueueSize,
+            nh_.subscribe<std_msgs::Bool>(imuTopic + std::string("/trusted"), imuQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                imuTopic + "_twist"), ros::VoidPtr(),
-                ros::TransportHints().tcpNoDelay(nodelayImu)));
-          topicSubs_.push_back(
-            nh_.subscribe<std_msgs::Bool>(imuTopic + std::string("/trusted/acceleration"), imuQueueSize,
-              boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                imuTopic + "_acceleration"), ros::VoidPtr(),
+                imuTopic), ros::VoidPtr(),
                 ros::TransportHints().tcpNoDelay(nodelayImu)));
         }
         else
@@ -1782,9 +1805,8 @@ namespace RobotLocalization
         }
 
         RF_DEBUG("Subscribed to " << imuTopic << " (" << imuTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << imuTopic << "/trusted/pose" << " (" << imuTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << imuTopic << "/trusted/twist" << " (" << imuTopicName << ")\n\t" <<
-                 "subscribed to trusting source " << imuTopic << "/trusted/acceleration" << " (" << imuTopicName << ")\n\t" <<
+                 "subscribed to trusting source " << imuTopic << "/trusted" << " (" << imuTopicName << ")\n\t" <<
+                 "subscribed to bias source " << imuTopic << "/bias" << " (" << imuTopicName << ")\n\t" <<
                  imuTopicName << "_differential is " << (differential ? "true" : "false") << "\n\t" <<
                  imuTopicName << "_pose_rejection_threshold is " << poseMahalanobisThresh << "\n\t" <<
                  imuTopicName << "_pose_rejection_threshold_init is " << poseMahalanobisThreshInit << "\n\t" <<
@@ -2103,16 +2125,24 @@ namespace RobotLocalization
                       measurement,
                       measurementCovariance))
       {
-        // Check which rejection threshold to use
+        // Check which rejection threshold to use and whether to use bias information
         double rejectionThreshold = callbackData.rejectionThreshold_;
-        if((sourceData_.find(topicName) != sourceData_.end() &&
-          (sourceData_[topicName].trusted_)))
+        if(sourceData_.find(topicName) != sourceData_.end())
         {
-          rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+          RF_VERBOSE("Has source data for topic " << topicName << " pose\n");
+          if(sourceData_[topicName].trusted_)
+          {
+            // Trusted source
+            rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+          }
+          if(sourceData_[topicName].bias_valid_)
+          {
+            // Use bias information
+            measurement += sourceData_[topicName].bias_pose_;
+          }
         }
         // Store the measurement. Add a "pose" suffix so we know what kind of measurement
         // we're dealing with when we debug the core filter logic.
-        // TODO: Determine if measurement is trusted and set mahalanobis distance accordingly
         enqueueMeasurement(topicName,
                            measurement,
                            measurementCovariance,
@@ -2178,14 +2208,23 @@ namespace RobotLocalization
     double secCurTime = curTime.toSec();
 
     // Handle any timeouts of trusted data
-    if(trusted_timeout_ > 0.0)
+    if((trusted_timeout_ > 0.0) || (bias_timeout_ > 0.0))
     {
       for(auto &item : sourceData_)
       {
-        if((item.second.trusted_ == true) && (secCurTime > (item.second.last_trusted_s_ + trusted_timeout_)))
+        if((trusted_timeout_ > 0.0) && 
+          (item.second.trusted_) &&
+          (secCurTime > (item.second.last_trusted_s_ + trusted_timeout_)))
         {
           // Trusted status timed out
           item.second.trusted_ = false;
+        }
+        if((bias_timeout_ > 0.0) && 
+          (item.second.bias_valid_) &&
+          (secCurTime > (item.second.last_bias_s_ + bias_timeout_)))
+        {
+          // Trusted status timed out
+          item.second.bias_valid_ = false;
         }
       }
     }
@@ -2480,12 +2519,21 @@ namespace RobotLocalization
       // Prepare the twist data for inclusion in the filter
       if (prepareTwist(msg, topicName, targetFrame, updateVectorCorrected, measurement, measurementCovariance))
       {
-        // Check which rejection threshold to use
+        // Check which rejection threshold to use and whether to use bias information
+        RF_VERBOSE("Has source data for topic " << topicName << " twist\n");
         double rejectionThreshold = callbackData.rejectionThreshold_;
-        if((sourceData_.find(topicName) != sourceData_.end() &&
-          (sourceData_[topicName].trusted_)))
+        if(sourceData_.find(topicName) != sourceData_.end())
         {
-          rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+          if(sourceData_[topicName].trusted_)
+          {
+            // Trusted source
+            rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+          }
+          if(sourceData_[topicName].bias_valid_)
+          {
+            // Use bias information
+            measurement += sourceData_[topicName].bias_twist_;
+          }
         }
         // Store the measurement. Add a "twist" suffix so we know what kind of measurement
         // we're dealing with when we debug the core filter logic.
@@ -2719,6 +2767,7 @@ namespace RobotLocalization
   bool RosFilter<T>::prepareAcceleration(const sensor_msgs::Imu::ConstPtr &msg,
                            const std::string &topicName,
                            const std::string &targetFrame,
+                           const bool &removeGravitationalAccel,
                            std::vector<int> &updateVector,
                            Eigen::VectorXd &measurement,
                            Eigen::MatrixXd &measurementCovariance)
@@ -2776,7 +2825,7 @@ namespace RobotLocalization
     {
       // We don't know if the user has already handled the removal
       // of normal forces, so we use a parameter
-      if (removeGravitationalAcc_[topicName])
+      if (removeGravitationalAccel)
       {
         tf2::Vector3 normAcc(0, 0, gravitationalAcc_);
         tf2::Transform trans;
@@ -3678,6 +3727,207 @@ namespace RobotLocalization
       measurementQueue_.pop();
     }
     return;
+  }
+
+  template<typename T>
+  void RosFilter<T>::biasOdometryCallback(const nav_msgs::Odometry::ConstPtr &msg, const std::string &topicName,
+    const CallbackData &poseCallbackData, const CallbackData &twistCallbackData)
+  {
+    RF_VERBOSE("------ RosFilter::biasOdometryCallback (" << topicName << ") ------\n" << "Odometry message:\n" << *msg);
+
+    if (poseCallbackData.updateSum_ > 0)
+    {
+      // Grab the pose portion of the message and pass it to the poseCallback
+      geometry_msgs::PoseWithCovarianceStamped *posPtr = new geometry_msgs::PoseWithCovarianceStamped();
+      posPtr->header = msg->header;
+      posPtr->pose = msg->pose;  // Entire pose object, also copies covariance
+
+      geometry_msgs::PoseWithCovarianceStampedConstPtr pptr(posPtr);
+      biasPoseCallback(pptr, poseCallbackData, worldFrameId_, false);
+    }
+
+    if (twistCallbackData.updateSum_ > 0)
+    {
+      // Grab the twist portion of the message and pass it to the twistCallback
+      geometry_msgs::TwistWithCovarianceStamped *twistPtr = new geometry_msgs::TwistWithCovarianceStamped();
+      twistPtr->header = msg->header;
+      twistPtr->header.frame_id = msg->child_frame_id;
+      twistPtr->twist = msg->twist;  // Entire twist object, also copies covariance
+
+      geometry_msgs::TwistWithCovarianceStampedConstPtr tptr(twistPtr);
+      biasTwistCallback(tptr, twistCallbackData, baseLinkFrameId_);
+    }
+
+    RF_VERBOSE("\n----- /RosFilter::biasOdometryCallback (" << topicName << ") ------\n");
+  }
+
+  template<typename T>
+  void RosFilter<T>::biasImuCallback(const sensor_msgs::Imu::ConstPtr &msg,
+                                 const std::string &topicName,
+                                 const CallbackData &poseCallbackData,
+                                 const CallbackData &twistCallbackData,
+                                 const CallbackData &accelCallbackData)
+  {
+    RF_VERBOSE("------ RosFilter::biasImuCallback (" << topicName << ") ------\n" << "IMU message:\n" << *msg);
+
+    // As with the odometry message, we can separate out the pose- and twist-related variables
+    // in the IMU message and pass them to the pose and twist callbacks (filters)
+    if (poseCallbackData.updateSum_ > 0)
+    {
+      // Extract the pose (orientation) data, pass it to its filter
+      geometry_msgs::PoseWithCovarianceStamped *posPtr = new geometry_msgs::PoseWithCovarianceStamped();
+      posPtr->header = msg->header;
+      posPtr->pose.pose.orientation = msg->orientation;
+
+      // IMU data gets handled a bit differently, since the message is ambiguous and has only a single frame_id,
+      // even though the data in it is reported in two different frames. As we assume users will specify a base_link
+      // to imu transform, we make the target frame baseLinkFrameId_ and tell the poseCallback that it is working
+      // with IMU data. This will cause it to apply different logic to the data.
+      geometry_msgs::PoseWithCovarianceStampedConstPtr pptr(posPtr);
+      biasPoseCallback(pptr, poseCallbackData, baseLinkFrameId_, true);
+    }
+
+    if (twistCallbackData.updateSum_ > 0)
+    {
+      // Repeat for velocity
+      geometry_msgs::TwistWithCovarianceStamped *twistPtr = new geometry_msgs::TwistWithCovarianceStamped();
+      twistPtr->header = msg->header;
+      twistPtr->twist.twist.angular = msg->angular_velocity;
+
+      geometry_msgs::TwistWithCovarianceStampedConstPtr tptr(twistPtr);
+      biasTwistCallback(tptr, twistCallbackData, baseLinkFrameId_);
+    }
+
+    if (accelCallbackData.updateSum_ > 0)
+    {
+      // Pass the message on
+      biasAccelerationCallback(msg, accelCallbackData, baseLinkFrameId_);
+    }
+
+    RF_VERBOSE("\n----- /RosFilter::biasImuCallback (" << topicName << ") ------\n");
+  }
+
+  template<typename T>
+  void RosFilter<T>::biasPoseCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr &msg,
+                                      const CallbackData &callbackData,
+                                      const std::string &targetFrame,
+                                      const bool imuData)
+  {
+    const std::string &topicName = callbackData.topicName_;
+
+    RF_VERBOSE("------ RosFilter::biasPoseCallback (" << topicName << ") ------\n" <<
+             "Pose message:\n" << *msg);
+
+    Eigen::VectorXd measurement(STATE_SIZE);
+    Eigen::MatrixXd measurementCovariance(STATE_SIZE, STATE_SIZE);
+
+    measurement.setZero();
+    measurementCovariance.setZero();
+
+    // Make sure we're actually updating at least one of these variables
+    std::vector<int> updateVectorCorrected = callbackData.updateVector_;
+
+    // Prepare the pose data for inclusion in the filter
+    if (preparePose(msg,
+                    topicName,
+                    targetFrame,
+                    callbackData.differential_,
+                    callbackData.relative_,
+                    imuData,
+                    updateVectorCorrected,
+                    measurement,
+                    measurementCovariance))
+    {
+      // Save the bias data
+      if(sourceData_.find(topicName) == sourceData_.end())
+      {
+        RF_VERBOSE("Adding pose source data for topic " << topicName << "\n");
+        // Create the new data storage for this source
+        sourceData_.emplace(topicName, SourceData());
+      }
+      sourceData_[topicName].bias_pose_ = measurement;
+      sourceData_[topicName].bias_valid_ = true;
+      sourceData_[topicName].last_bias_s_ = msg->header.stamp.toSec();
+      RF_VERBOSE("Bias data for topic " << topicName << " updated to " << measurement);
+    }
+
+    RF_VERBOSE("\n----- /RosFilter::biasPoseCallback (" << topicName << ") ------\n");
+  }
+
+  template<typename T>
+  void RosFilter<T>::biasTwistCallback(const geometry_msgs::TwistWithCovarianceStamped::ConstPtr &msg,
+                                   const CallbackData &callbackData,
+                                   const std::string &targetFrame)
+  {
+    const std::string &topicName = callbackData.topicName_;
+
+    RF_VERBOSE("------ RosFilter::biasTwistCallback (" << topicName << ") ------\n"
+             "Twist message:\n" << *msg);
+
+    Eigen::VectorXd measurement(STATE_SIZE);
+    Eigen::MatrixXd measurementCovariance(STATE_SIZE, STATE_SIZE);
+
+    measurement.setZero();
+    measurementCovariance.setZero();
+
+    // Make sure we're actually updating at least one of these variables
+    std::vector<int> updateVectorCorrected = callbackData.updateVector_;
+
+    // Prepare the twist data for inclusion in the filter
+    if (prepareTwist(msg, topicName, targetFrame, updateVectorCorrected, measurement, measurementCovariance))
+    {
+      // Save the bias data
+      if(sourceData_.find(topicName) == sourceData_.end())
+      {
+        RF_VERBOSE("Adding twist source data for topic " << topicName << "\n");
+        // Create the new data storage for this source
+        sourceData_.emplace(topicName, SourceData());
+      }
+      sourceData_[topicName].bias_twist_ = measurement;
+      sourceData_[topicName].bias_valid_ = true;
+      sourceData_[topicName].last_bias_s_ = msg->header.stamp.toSec();
+      RF_VERBOSE("Bias data for topic " << topicName << " updated to " << measurement);
+    }
+
+    RF_VERBOSE("\n----- /RosFilter::biasTwistCallback (" << topicName << ") ------\n");
+  }
+
+  template<typename T>
+  void RosFilter<T>::biasAccelerationCallback(const sensor_msgs::Imu::ConstPtr &msg, const CallbackData &callbackData,
+    const std::string &targetFrame)
+  {
+    const std::string &topicName = callbackData.topicName_;
+
+    RF_VERBOSE("------ RosFilter::biasAccelerationCallback (" << topicName << ") ------\n"
+             "Twist message:\n" << *msg);
+
+    Eigen::VectorXd measurement(STATE_SIZE);
+    Eigen::MatrixXd measurementCovariance(STATE_SIZE, STATE_SIZE);
+
+    measurement.setZero();
+    measurementCovariance.setZero();
+
+    // Make sure we're actually updating at least one of these variables
+    std::vector<int> updateVectorCorrected = callbackData.updateVector_;
+
+    // Prepare the twist data for inclusion in the filter
+    // Bias never includes the gravitational acceleration handling
+    if (prepareAcceleration(msg, topicName, targetFrame, false, updateVectorCorrected, measurement,
+          measurementCovariance))
+    {
+      // Save the bias data
+      if(sourceData_.find(topicName) == sourceData_.end())
+      {
+        // Create the new data storage for this source
+        sourceData_.emplace(topicName, SourceData());
+      }
+      sourceData_[topicName].bias_acceleration_ = measurement;
+      sourceData_[topicName].bias_valid_ = true;
+      sourceData_[topicName].last_bias_s_ = msg->header.stamp.toSec();
+      RF_VERBOSE("Bias data for topic " << topicName << " updated to " << measurement);
+    }
+
+    RF_VERBOSE("\n----- /RosFilter::biasAccelerationCallback (" << topicName << ") ------\n");
   }
 }  // namespace RobotLocalization
 


### PR DESCRIPTION
Added two major capabilities:
1) The concept of trusted sensor data. In this case, an external system (e.g. a monitor) can tell the robot_localization package the the sensor data is to be trusted and to use a different mahalanobis distance (typically a much higher threshold so the data will be accepted unless there is truly an outlier). A timeout can be set such that the trusted setting will automatically revert to false if the data is not consistently updated to remain trusted. The monitor can also tell the robot_localization package that the sensor data is no longer trusted, so it reverts to the typical rejection threshold. This capability is generic for all sensor inputs. Note that the default setting is false/not trusted, so if the trusted setting is never sent, then the system behaves as normal (e.g. backwards compatible).
2) The concept of sensor data bias. In this case, an external system can send the same sensor data format (e.g. an IMU message for IMU data) that contains bias data. Again, a timeout is available if set. In this case, if the data is considered valid, then robot_localization will automatically include the bias offset when incorporating the data. This method prevents a delay in the sensor data by combining the data when pulled into the EKF. The data is unused if never set and defaults to a zero bias, so if only part of the data has a bias (e.g. the twist data for the IMU), then the acceleration data is left with zero bias, resulting in backwards compatibility.

This has been tested in simulation. Testing is necessary on the vehicle prior to merging into noetic-devel.