### PR TITLE
Publish Mahalanobis distance per input source

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-robot-localization (102.7.3-focal9) focal; urgency=medium
+
+  * Adding publisher for mahalanobis distance via configuration.
+
+ -- Jonathan Sanabria <jonathan@greenzie.com>  Mon, 05 Dec 2022 10:18:48 -0500
+
 ros-noetic-robot-localization (102.7.3-focal8) focal; urgency=medium
 
   * Added trusted inputs and bias handling

--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -64,7 +64,7 @@ struct Measurement
   double latestControlTime_;
 
   // Always log the mahalanobis distance for the particula measurement if the debug flag is on
-  bool debugLogMahalanobisDistance_;
+  bool publishMahalanobisDistance_;
 
   // The Mahalanobis distance threshold in number of sigmas
   double mahalanobisThresh_;
@@ -388,6 +388,15 @@ class FilterBase
     //!
     void setSaveRejectedMeasurementTopics(bool save);
 
+    //! @brief Returns a copy of any rejected measurements topics and clears the internal vector
+    //!
+    //! @param[out] rejected - vector of rejected measurement topics since the last call
+    //!
+    std::map<std::string, double> getCopyAndClearMahalanobisDistanceMap()
+    { 
+      return std::move(measurementMapPeriodicMaxSquaredMahalanobisDistance_);
+    };
+
   protected:
     //! @brief Method for settings bounds on acceleration values derived from controls
     //! @param[in] state - The current state variable (e.g., linear X velocity)
@@ -436,20 +445,18 @@ class FilterBase
     virtual void wrapStateAngles();
 
     //! @brief Tests if innovation is within N-sigmas of covariance. Returns true if passed the test.
-    //! @param[in] innovation - The difference between the measurement and the state
-    //! @param[in] invCovariance - The innovation error
+    //! @param[in] sqMahalanobis - the squared mahalanobis distance
     //! @param[in] nsigmas - Number of standard deviations that are considered acceptable
     //!
-    virtual bool checkMahalanobisThreshold(const Eigen::VectorXd &innovation,
-                                           const Eigen::MatrixXd &invCovariance,
+    virtual bool checkMahalanobisThreshold(const double sqMahalanobis,
                                            const double nsigmas);
 
-    //! @brief Logs the mahalanobis distance if in debug mode. Useful if inspecting a measurement from a particular source. Or on a specific dimension.
+    //! @brief calculates mahalanobis distance if in debug mode.
     //! @param[in] innovation - The difference between the measurement and the state
     //! @param[in] invCovariance - The innovation error
     //!
-    virtual void logMahalanobisThreshold(const Eigen::VectorXd &innovation,
-                                           const Eigen::MatrixXd &invCovariance);
+    virtual double getSquaredMahalanobisDistance(const Eigen::VectorXd &innovation,
+                                             const Eigen::MatrixXd &invCovariance);
 
     //! @brief Converts the control term to an acceleration to be applied in the prediction step
     //! @param[in] referenceTime - The time of the update (measurement used in the prediction step)
@@ -584,6 +591,12 @@ class FilterBase
     //! matrix with respect to each state variable.
     //!
     Eigen::MatrixXd transferFunctionJacobian_;
+
+    //! @brief Holds the last maximum Squared mahalanobis distance per periodic update update/ROS publish
+    //!
+    //! Enables other nodes/nodelets within ROS to track the squared mahalanobis distance per measurement
+    //!
+    std::map<std::string, double> measurementMapPeriodicMaxSquaredMahalanobisDistance_;
 
     //! @brief Holds any rejected measurement topics since the last prediction update/ROS publish
     //!

--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -388,9 +388,9 @@ class FilterBase
     //!
     void setSaveRejectedMeasurementTopics(bool save);
 
-    //! @brief Returns a copy of any rejected measurements topics and clears the internal vector
+    //! @brief Returns a copy of the Mahalanobis distance map and clears the member variables data.
     //!
-    //! @param[out] rejected - vector of rejected measurement topics since the last call
+    //! @return the latest topic-to-mahalanobis distance map.
     //!
     std::map<std::string, double> getCopyAndClearMahalanobisDistanceMap()
     { 

--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -63,7 +63,7 @@ struct Measurement
   // The time stamp of the most recent control term (needed for lagged data)
   double latestControlTime_;
 
-  // Always log the mahalanobis distance for the particula measurement if the debug flag is on
+  // Always publish the mahalanobis distance for the particular measurement
   bool publishMahalanobisDistance_;
 
   // The Mahalanobis distance threshold in number of sigmas

--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -63,6 +63,9 @@ struct Measurement
   // The time stamp of the most recent control term (needed for lagged data)
   double latestControlTime_;
 
+  // Always log the mahalanobis distance for the particula measurement if the debug flag is on
+  bool debugLogMahalanobisDistance_;
+
   // The Mahalanobis distance threshold in number of sigmas
   double mahalanobisThresh_;
 
@@ -440,6 +443,13 @@ class FilterBase
     virtual bool checkMahalanobisThreshold(const Eigen::VectorXd &innovation,
                                            const Eigen::MatrixXd &invCovariance,
                                            const double nsigmas);
+
+    //! @brief Logs the mahalanobis distance if in debug mode. Useful if inspecting a measurement from a particular source. Or on a specific dimension.
+    //! @param[in] innovation - The difference between the measurement and the state
+    //! @param[in] invCovariance - The innovation error
+    //!
+    virtual void logMahalanobisThreshold(const Eigen::VectorXd &innovation,
+                                           const Eigen::MatrixXd &invCovariance);
 
     //! @brief Converts the control term to an acceleration to be applied in the prediction step
     //! @param[in] referenceTime - The time of the update (measurement used in the prediction step)

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -831,6 +831,8 @@ template<class T> class RosFilter
     ros::Publisher positionPub_;
 
     //! @brief A map of publishers per each odometry topic with the param set for publishing
+    //! the topic names are organized by the data they hold,
+    //! regex example == /odometry_outname/(odom|pose|twist|imu)[0-9]_(pose|twist|acceleration)/squared_mahalanobis_dist
     //!
     std::map<std::string, ros::Publisher> mahalanobisDistancePubMap_;
 

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -84,6 +84,7 @@ struct CallbackData
                const int updateSum,
                const bool differential,
                const bool relative,
+               const bool debugLogMahalanobisDistance,
                const double rejectionThreshold,
                const double rejectionThresholdInit,
                const double rejectionThresholdTrusted) :
@@ -92,6 +93,7 @@ struct CallbackData
     updateSum_(updateSum),
     differential_(differential),
     relative_(relative),
+    debugLogMahalanobisDistance_(debugLogMahalanobisDistance),
     rejectionThreshold_(rejectionThreshold),
     rejectionThresholdInit_(rejectionThresholdInit),
     rejectionThresholdTrusted_(rejectionThresholdTrusted)
@@ -103,6 +105,7 @@ struct CallbackData
   int updateSum_;
   bool differential_;
   bool relative_;
+  bool debugLogMahalanobisDistance_;
   double rejectionThreshold_;
   double rejectionThresholdInit_;
   double rejectionThresholdTrusted_;
@@ -207,6 +210,7 @@ template<class T> class RosFilter
                             const Eigen::VectorXd &measurement,
                             const Eigen::MatrixXd &measurementCovariance,
                             const std::vector<int> &updateVector,
+                            const bool debugLogMahalanobisDistance,
                             const double mahalanobisThresh,
                             const double mahalanobisThreshInit,
                             const ros::Time &time);

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -42,6 +42,7 @@
 #include <robot_localization/ToggleFilterProcessing.h>
 
 #include <ros/ros.h>
+#include <std_msgs/Float64.h>
 #include <std_msgs/String.h>
 #include <std_msgs/Bool.h>
 #include <std_srvs/Empty.h>
@@ -84,7 +85,7 @@ struct CallbackData
                const int updateSum,
                const bool differential,
                const bool relative,
-               const bool debugLogMahalanobisDistance,
+               const bool publishMahalanobisDistance,
                const double rejectionThreshold,
                const double rejectionThresholdInit,
                const double rejectionThresholdTrusted) :
@@ -93,7 +94,7 @@ struct CallbackData
     updateSum_(updateSum),
     differential_(differential),
     relative_(relative),
-    debugLogMahalanobisDistance_(debugLogMahalanobisDistance),
+    publishMahalanobisDistance_(publishMahalanobisDistance),
     rejectionThreshold_(rejectionThreshold),
     rejectionThresholdInit_(rejectionThresholdInit),
     rejectionThresholdTrusted_(rejectionThresholdTrusted)
@@ -105,7 +106,7 @@ struct CallbackData
   int updateSum_;
   bool differential_;
   bool relative_;
-  bool debugLogMahalanobisDistance_;
+  bool publishMahalanobisDistance_;
   double rejectionThreshold_;
   double rejectionThresholdInit_;
   double rejectionThresholdTrusted_;
@@ -210,7 +211,7 @@ template<class T> class RosFilter
                             const Eigen::VectorXd &measurement,
                             const Eigen::MatrixXd &measurementCovariance,
                             const std::vector<int> &updateVector,
-                            const bool debugLogMahalanobisDistance,
+                            const bool publishMahalanobisDistance,
                             const double mahalanobisThresh,
                             const double mahalanobisThreshInit,
                             const ros::Time &time);
@@ -828,6 +829,10 @@ template<class T> class RosFilter
     //! @brief position publisher
     //!
     ros::Publisher positionPub_;
+
+    //! @brief A map of publishers per each odometry topic with the param set for publishing
+    //!
+    std::map<std::string, ros::Publisher> mahalanobisDistancePubMap_;
 
     //! @brief rejected measurements topics publisher
     //!

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -179,15 +179,21 @@ namespace RobotLocalization
     prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
                    kalmanGainSubset, hphrInv, stateToMeasurementSubset);
 
-    if ( measurement.debugLogMahalanobisDistance_)
+    double sqMahalanobis = getSquaredMahalanobisDistance(innovationSubset, hphrInv);
+    if ( measurement.publishMahalanobisDistance_)
     {
-      // TODO add to filter base and ukf
-      FB_DEBUG("logMahalanobisThreshold - "<<measurement.topicName_);
-      logMahalanobisThreshold(innovationSubset, hphrInv);
+     //  Useful if inspecting a measurement from a particular source. Or on a specific dimension.
+      std::map<std::string, double>& mDistMap = measurementMapPeriodicMaxSquaredMahalanobisDistance_;
+      if(auto search = mDistMap.find(measurement.topicName_); search == mDistMap.end())
+      {
+        mDistMap[measurement.topicName_] = sqMahalanobis;
+      }
+      double &mDistReference = mDistMap.at(measurement.topicName_);
+      // we filter for the max per each periodic update
+      mDistReference = std::max(mDistReference, sqMahalanobis);
     }
-
     // (2) Check Mahalanobis distance between mapped measurement and state.
-    if (checkMahalanobisThreshold(innovationSubset, hphrInv, measurement.mahalanobisThresh_))
+    if (checkMahalanobisThreshold(sqMahalanobis, measurement.mahalanobisThresh_))
     {
       // (3) Apply the gain to the difference between the state and measurement: x = x + K(z - Hx)
       state_.noalias() += kalmanGainSubset * innovationSubset;

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -187,7 +187,7 @@ namespace RobotLocalization
     FB_DEBUG("Squared Mahalanobis is: " << sqMahalanobis << "\n" <<
               "Threshold is: " << measurement.mahalanobisThresh_*measurement.mahalanobisThresh_ << "\n" <<
               "Innovation is: " << innovationSubset << "\n" <<
-              "Innovation covariance is:\n" << innovMatInv << "\n");
+              "Innovation covariance is:\n" << hphrInv << "\n");
     if ( measurement.publishMahalanobisDistance_)
     {
      //  Useful if inspecting a measurement from a particular source. Or on a specific dimension.

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -179,6 +179,13 @@ namespace RobotLocalization
     prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
                    kalmanGainSubset, hphrInv, stateToMeasurementSubset);
 
+    if ( measurement.debugLogMahalanobisDistance_)
+    {
+      // TODO add to filter base and ukf
+      FB_DEBUG("logMahalanobisThreshold - "<<measurement.topicName_);
+      logMahalanobisThreshold(innovationSubset, hphrInv);
+    }
+
     // (2) Check Mahalanobis distance between mapped measurement and state.
     if (checkMahalanobisThreshold(innovationSubset, hphrInv, measurement.mahalanobisThresh_))
     {

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -491,4 +491,11 @@ namespace RobotLocalization
 
     return true;
   }
+
+  void FilterBase::logMahalanobisThreshold(const Eigen::VectorXd &innovation,
+                                             const Eigen::MatrixXd &invCovariance)
+  {
+    double sqMahalanobis = innovation.dot(invCovariance * innovation);
+    FB_DEBUG("Squared Mahalanobis is," << sqMahalanobis << "\n");
+  }
 }  // namespace RobotLocalization

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -281,7 +281,20 @@ namespace RobotLocalization
       prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
                      kalmanGainSubset, innovMatInv, auxMat);
 
-      if (checkMahalanobisThreshold(innovationSubset, innovMatInv, measurement.mahalanobisThreshInit_))
+      double sqMahalanobis = getSquaredMahalanobisDistance(innovationSubset, innovMatInv);
+      if ( measurement.publishMahalanobisDistance_)
+      {
+      //  Useful if inspecting a measurement from a particular source. Or on a specific dimension.
+      std::map<std::string, double>& mDistMap = measurementMapPeriodicMaxSquaredMahalanobisDistance_;
+      if(auto search = mDistMap.find(measurement.topicName_); search == mDistMap.end())
+      {
+        mDistMap[measurement.topicName_] = sqMahalanobis;
+      }
+      double &mDistReference = mDistMap.at(measurement.topicName_);
+        // we filter for the max per each periodic update
+        mDistReference = std::max(mDistReference, sqMahalanobis);
+      }
+      if (checkMahalanobisThreshold(sqMahalanobis, measurement.mahalanobisThreshInit_))
       {
         FB_VERBOSE("First measurement. Initializing filter.\n");
 
@@ -472,30 +485,21 @@ namespace RobotLocalization
     state_(StateMemberYaw)   = FilterUtilities::clampRotation(state_(StateMemberYaw));
   }
 
-  bool FilterBase::checkMahalanobisThreshold(const Eigen::VectorXd &innovation,
-                                             const Eigen::MatrixXd &invCovariance,
+  bool FilterBase::checkMahalanobisThreshold(const double sqMahalanobis,
                                              const double nsigmas)
   {
-    double sqMahalanobis = innovation.dot(invCovariance * innovation);
-    double threshold = nsigmas * nsigmas;
-
+    double threshold = nsigmas*nsigmas;
     if (sqMahalanobis >= threshold)
     {
-      FB_DEBUG("Innovation mahalanobis distance test failed. Squared Mahalanobis is: " << sqMahalanobis << "\n" <<
-               "Threshold is: " << threshold << "\n" <<
-               "Innovation is: " << innovation << "\n" <<
-               "Innovation covariance is:\n" << invCovariance << "\n");
-
       return false;
     }
-
     return true;
   }
 
-  void FilterBase::logMahalanobisThreshold(const Eigen::VectorXd &innovation,
+  double FilterBase::getSquaredMahalanobisDistance(const Eigen::VectorXd &innovation,
                                              const Eigen::MatrixXd &invCovariance)
   {
     double sqMahalanobis = innovation.dot(invCovariance * innovation);
-    FB_DEBUG("Squared Mahalanobis is," << sqMahalanobis << "\n");
+    return sqMahalanobis;
   }
 }  // namespace RobotLocalization

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -275,6 +275,7 @@ namespace RobotLocalization
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
+                           callbackData.debugLogMahalanobisDistance_,
                            rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
@@ -352,6 +353,7 @@ namespace RobotLocalization
                                         const Eigen::VectorXd &measurement,
                                         const Eigen::MatrixXd &measurementCovariance,
                                         const std::vector<int> &updateVector,
+                                        const bool debugLogMahalanobisDistance,
                                         const double mahalanobisThresh,
                                         const double mahalanobisThreshInit,
                                         const ros::Time &time)
@@ -363,6 +365,7 @@ namespace RobotLocalization
     meas->covariance_ = measurementCovariance;
     meas->updateVector_ = updateVector;
     meas->time_ = time.toSec();
+    meas->debugLogMahalanobisDistance_ = debugLogMahalanobisDistance;
     meas->mahalanobisThresh_ = mahalanobisThresh;
     meas->mahalanobisThreshInit_ = mahalanobisThreshInit;
     meas->latestControl_ = latestControl_;
@@ -1182,6 +1185,10 @@ namespace RobotLocalization
         nhLocal_.getParam(odomTopicName, odomTopic);
 
         // Check for pose rejection threshold
+        bool debugLogMahalanobisDistance;
+        nhLocal_.param(odomTopicName + std::string("_debug_log_mahalanobis_distance"),
+                       debugLogMahalanobisDistance,
+                       false);
         double poseMahalanobisThresh;
         nhLocal_.param(odomTopicName + std::string("_pose_rejection_threshold"),
                        poseMahalanobisThresh,
@@ -1224,9 +1231,9 @@ namespace RobotLocalization
         nhLocal_.param(odomTopicName + "_queue_size", odomQueueSize, 1);
 
         const CallbackData poseCallbackData(odomTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
-          relative, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
+          relative, debugLogMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
         const CallbackData twistCallbackData(odomTopicName + "_twist", twistUpdateVec, twistUpdateSum, false, false,
-          twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
+        false, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
 
         bool nodelayOdom = false;
         nhLocal_.param(odomTopicName + "_nodelay", nodelayOdom, false);
@@ -1343,6 +1350,10 @@ namespace RobotLocalization
         nhLocal_.getParam(poseTopicName, poseTopic);
 
         // Check for pose rejection threshold
+        bool debugLogMahalanobisDistance;
+        nhLocal_.param(poseTopicName + std::string("_debug_log_mahalanobis_distance"),
+                       debugLogMahalanobisDistance,
+                       false);
         double poseMahalanobisThresh;
         nhLocal_.param(poseTopicName + std::string("_rejection_threshold"),
                        poseMahalanobisThresh,
@@ -1376,7 +1387,7 @@ namespace RobotLocalization
         if (poseUpdateSum > 0)
         {
           const CallbackData callbackData(poseTopicName, poseUpdateVec, poseUpdateSum, differential, relative,
-            poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
+                                     debugLogMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(poseTopic, poseQueueSize,
@@ -1450,6 +1461,10 @@ namespace RobotLocalization
         nhLocal_.getParam(twistTopicName, twistTopic);
 
         // Check for twist rejection threshold
+        bool debugLogMahalanobisDistance;
+        nhLocal_.param(twistTopicName + std::string("_debug_log_mahalanobis_distance"),
+                       debugLogMahalanobisDistance,
+                       false);
         double twistMahalanobisThresh;
         nhLocal_.param(twistTopicName + std::string("_rejection_threshold"),
                        twistMahalanobisThresh,
@@ -1478,7 +1493,7 @@ namespace RobotLocalization
         if (twistUpdateSum > 0)
         {
           const CallbackData callbackData(twistTopicName, twistUpdateVec, twistUpdateSum, false, false,
-            twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
+          debugLogMahalanobisDistance, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(twistTopic, twistQueueSize,
@@ -1554,6 +1569,10 @@ namespace RobotLocalization
         nhLocal_.getParam(imuTopicName, imuTopic);
 
         // Check for pose rejection threshold
+        bool debugLogMahalanobisDistance;
+        nhLocal_.param(imuTopicName + std::string("_debug_log_mahalanobis_distance"),
+                       debugLogMahalanobisDistance,
+                       false);
         double poseMahalanobisThresh;
         nhLocal_.param(imuTopicName + std::string("_pose_rejection_threshold"),
                        poseMahalanobisThresh,
@@ -1684,12 +1703,13 @@ namespace RobotLocalization
 
         if (poseUpdateSum + twistUpdateSum + accelUpdateSum > 0)
         {
+          // TODO check debugLogMahalanobisDistance for IMU odometry source
           const CallbackData poseCallbackData(imuTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
-            relative, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
+            relative, debugLogMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
           const CallbackData twistCallbackData(imuTopicName + "_twist", twistUpdateVec, twistUpdateSum, differential,
-            relative, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
+            relative, debugLogMahalanobisDistance, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
           const CallbackData accelCallbackData(imuTopicName + "_acceleration", accelUpdateVec, accelUpdateSum,
-            differential, relative, accelMahalanobisThresh, accelMahalanobisThreshInit, accelMahalanobisThreshTrusted);
+            differential, relative, debugLogMahalanobisDistance, accelMahalanobisThresh, accelMahalanobisThreshInit, accelMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<sensor_msgs::Imu>(imuTopic, imuQueueSize,
@@ -2147,6 +2167,7 @@ namespace RobotLocalization
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
+                           callbackData.debugLogMahalanobisDistance_,
                            rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
@@ -2541,6 +2562,7 @@ namespace RobotLocalization
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
+                           callbackData.debugLogMahalanobisDistance_,
                            rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -275,7 +275,7 @@ namespace RobotLocalization
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
-                           callbackData.debugLogMahalanobisDistance_,
+                           callbackData.publishMahalanobisDistance_,
                            rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
@@ -353,7 +353,7 @@ namespace RobotLocalization
                                         const Eigen::VectorXd &measurement,
                                         const Eigen::MatrixXd &measurementCovariance,
                                         const std::vector<int> &updateVector,
-                                        const bool debugLogMahalanobisDistance,
+                                        const bool publishMahalanobisDistance,
                                         const double mahalanobisThresh,
                                         const double mahalanobisThreshInit,
                                         const ros::Time &time)
@@ -365,7 +365,7 @@ namespace RobotLocalization
     meas->covariance_ = measurementCovariance;
     meas->updateVector_ = updateVector;
     meas->time_ = time.toSec();
-    meas->debugLogMahalanobisDistance_ = debugLogMahalanobisDistance;
+    meas->publishMahalanobisDistance_ = publishMahalanobisDistance;
     meas->mahalanobisThresh_ = mahalanobisThresh;
     meas->mahalanobisThreshInit_ = mahalanobisThreshInit;
     meas->latestControl_ = latestControl_;
@@ -1185,10 +1185,14 @@ namespace RobotLocalization
         nhLocal_.getParam(odomTopicName, odomTopic);
 
         // Check for pose rejection threshold
-        bool debugLogMahalanobisDistance;
-        nhLocal_.param(odomTopicName + std::string("_debug_log_mahalanobis_distance"),
-                       debugLogMahalanobisDistance,
+        bool publishMahalanobisDistance;
+        nhLocal_.param(odomTopicName + std::string("_publish_mahalanobis_distance"),
+                       publishMahalanobisDistance,
                        false);
+        if (publishMahalanobisDistance)
+        {
+          mahalanobisDistancePubMap_[odomTopicName+ "_pose"] = nhLocal_.advertise<std_msgs::Float64>(odomTopicName+ "_pose" + "/squared_mahalanobis_dist", 20);
+        }
         double poseMahalanobisThresh;
         nhLocal_.param(odomTopicName + std::string("_pose_rejection_threshold"),
                        poseMahalanobisThresh,
@@ -1203,6 +1207,11 @@ namespace RobotLocalization
                        std::numeric_limits<double>::max());
 
         // Check for twist rejection threshold
+        if (publishMahalanobisDistance)
+        {
+          // use the pose param result for the odom source
+          mahalanobisDistancePubMap_[odomTopicName+ "_twist"] = nhLocal_.advertise<std_msgs::Float64>(odomTopicName+ "_twist" + "/squared_mahalanobis_dist", 20);
+        }
         double twistMahalanobisThresh;
         nhLocal_.param(odomTopicName + std::string("_twist_rejection_threshold"),
                        twistMahalanobisThresh,
@@ -1231,7 +1240,7 @@ namespace RobotLocalization
         nhLocal_.param(odomTopicName + "_queue_size", odomQueueSize, 1);
 
         const CallbackData poseCallbackData(odomTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
-          relative, debugLogMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
+          relative, publishMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
         const CallbackData twistCallbackData(odomTopicName + "_twist", twistUpdateVec, twistUpdateSum, false, false,
         false, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
 
@@ -1350,10 +1359,14 @@ namespace RobotLocalization
         nhLocal_.getParam(poseTopicName, poseTopic);
 
         // Check for pose rejection threshold
-        bool debugLogMahalanobisDistance;
-        nhLocal_.param(poseTopicName + std::string("_debug_log_mahalanobis_distance"),
-                       debugLogMahalanobisDistance,
+        bool publishMahalanobisDistance;
+        nhLocal_.param(poseTopicName + std::string("_publish_mahalanobis_distance"),
+                       publishMahalanobisDistance,
                        false);
+        if (publishMahalanobisDistance)
+        {
+          mahalanobisDistancePubMap_[poseTopicName] = nhLocal_.advertise<std_msgs::Float64>(poseTopicName + "/squared_mahalanobis_dist", 20);
+        }
         double poseMahalanobisThresh;
         nhLocal_.param(poseTopicName + std::string("_rejection_threshold"),
                        poseMahalanobisThresh,
@@ -1387,7 +1400,7 @@ namespace RobotLocalization
         if (poseUpdateSum > 0)
         {
           const CallbackData callbackData(poseTopicName, poseUpdateVec, poseUpdateSum, differential, relative,
-                                     debugLogMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
+                                     publishMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<geometry_msgs::PoseWithCovarianceStamped>(poseTopic, poseQueueSize,
@@ -1461,10 +1474,14 @@ namespace RobotLocalization
         nhLocal_.getParam(twistTopicName, twistTopic);
 
         // Check for twist rejection threshold
-        bool debugLogMahalanobisDistance;
-        nhLocal_.param(twistTopicName + std::string("_debug_log_mahalanobis_distance"),
-                       debugLogMahalanobisDistance,
+        bool publishMahalanobisDistance;
+        nhLocal_.param(twistTopicName + std::string("_publish_mahalanobis_distance"),
+                       publishMahalanobisDistance,
                        false);
+        if (publishMahalanobisDistance)
+        {
+          mahalanobisDistancePubMap_[twistTopicName] = nhLocal_.advertise<std_msgs::Float64>(twistTopicName + "/squared_mahalanobis_dist", 20);
+        }
         double twistMahalanobisThresh;
         nhLocal_.param(twistTopicName + std::string("_rejection_threshold"),
                        twistMahalanobisThresh,
@@ -1493,7 +1510,7 @@ namespace RobotLocalization
         if (twistUpdateSum > 0)
         {
           const CallbackData callbackData(twistTopicName, twistUpdateVec, twistUpdateSum, false, false,
-          debugLogMahalanobisDistance, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
+          publishMahalanobisDistance, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<geometry_msgs::TwistWithCovarianceStamped>(twistTopic, twistQueueSize,
@@ -1569,10 +1586,14 @@ namespace RobotLocalization
         nhLocal_.getParam(imuTopicName, imuTopic);
 
         // Check for pose rejection threshold
-        bool debugLogMahalanobisDistance;
-        nhLocal_.param(imuTopicName + std::string("_debug_log_mahalanobis_distance"),
-                       debugLogMahalanobisDistance,
+        bool publishMahalanobisDistance;
+        nhLocal_.param(imuTopicName + std::string("_publish_mahalanobis_distance"),
+                       publishMahalanobisDistance,
                        false);
+        if (publishMahalanobisDistance)
+        {
+          mahalanobisDistancePubMap_[imuTopicName + "_pose"] = nhLocal_.advertise<std_msgs::Float64>(imuTopicName + "_pose" + "/squared_mahalanobis_dist", 20);
+        }
         double poseMahalanobisThresh;
         nhLocal_.param(imuTopicName + std::string("_pose_rejection_threshold"),
                        poseMahalanobisThresh,
@@ -1587,6 +1608,11 @@ namespace RobotLocalization
                        std::numeric_limits<double>::max());
 
         // Check for angular velocity rejection threshold
+        if (publishMahalanobisDistance)
+        {
+          // use the pose param result for the imu source
+          mahalanobisDistancePubMap_[imuTopicName + "_twist"] = nhLocal_.advertise<std_msgs::Float64>(imuTopicName + "_twist" + "/squared_mahalanobis_dist", 20);
+        }
         double twistMahalanobisThresh;
         std::string imuTwistRejectionName =
           imuTopicName + std::string("_twist_rejection_threshold");
@@ -1601,6 +1627,11 @@ namespace RobotLocalization
         nhLocal_.param(imuTwistRejectionName, twistMahalanobisThreshTrusted, std::numeric_limits<double>::max());
 
         // Check for acceleration rejection threshold
+        if (publishMahalanobisDistance)
+        {
+          // use the pose param result for the imu source
+          mahalanobisDistancePubMap_[imuTopicName + "_acceleration"] = nhLocal_.advertise<std_msgs::Float64>(imuTopicName + "_acceleration" + "/squared_mahalanobis_dist", 20);
+        }
         double accelMahalanobisThresh;
         nhLocal_.param(imuTopicName + std::string("_linear_acceleration_rejection_threshold"),
                        accelMahalanobisThresh,
@@ -1703,13 +1734,13 @@ namespace RobotLocalization
 
         if (poseUpdateSum + twistUpdateSum + accelUpdateSum > 0)
         {
-          // TODO check debugLogMahalanobisDistance for IMU odometry source
+          // TODO check publishMahalanobisDistance for IMU odometry source
           const CallbackData poseCallbackData(imuTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
-            relative, debugLogMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
+            relative, publishMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
           const CallbackData twistCallbackData(imuTopicName + "_twist", twistUpdateVec, twistUpdateSum, differential,
-            relative, debugLogMahalanobisDistance, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
+            relative, publishMahalanobisDistance, twistMahalanobisThresh, twistMahalanobisThreshInit, twistMahalanobisThreshTrusted);
           const CallbackData accelCallbackData(imuTopicName + "_acceleration", accelUpdateVec, accelUpdateSum,
-            differential, relative, debugLogMahalanobisDistance, accelMahalanobisThresh, accelMahalanobisThreshInit, accelMahalanobisThreshTrusted);
+            differential, relative, publishMahalanobisDistance, accelMahalanobisThresh, accelMahalanobisThreshInit, accelMahalanobisThreshTrusted);
 
           topicSubs_.push_back(
             nh_.subscribe<sensor_msgs::Imu>(imuTopic, imuQueueSize,
@@ -2167,7 +2198,7 @@ namespace RobotLocalization
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
-                           callbackData.debugLogMahalanobisDistance_,
+                           callbackData.publishMahalanobisDistance_,
                            rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);
@@ -2385,6 +2416,19 @@ namespace RobotLocalization
       accelPub_.publish(filteredAcceleration);
     }
 
+    // Publish Squared Mahalanobis distances and clear the mDistMap for the next periodic update
+    std::map<std::string,double> mDistMap = filter_.getCopyAndClearMahalanobisDistanceMap();
+    for (auto &kv: mDistMap)
+    {
+      auto search = mahalanobisDistancePubMap_.find(kv.first); 
+      if(search != mahalanobisDistancePubMap_.end())
+      {
+        std_msgs::Float64 sendMsg;
+        sendMsg.data = kv.second;
+        mahalanobisDistancePubMap_[kv.first].publish(sendMsg);
+      }
+    }
+
     // Publish rejected measurement topics since last predict cycle, if desired
     if (publishRejectedMeasurements_)
     {
@@ -2562,7 +2606,7 @@ namespace RobotLocalization
                            measurement,
                            measurementCovariance,
                            updateVectorCorrected,
-                           callbackData.debugLogMahalanobisDistance_,
+                           callbackData.publishMahalanobisDistance_,
                            rejectionThreshold,
                            callbackData.rejectionThresholdInit_,
                            msg->header.stamp);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1734,7 +1734,6 @@ namespace RobotLocalization
 
         if (poseUpdateSum + twistUpdateSum + accelUpdateSum > 0)
         {
-          // TODO check publishMahalanobisDistance for IMU odometry source
           const CallbackData poseCallbackData(imuTopicName + "_pose", poseUpdateVec, poseUpdateSum, differential,
             relative, publishMahalanobisDistance, poseMahalanobisThresh, poseMahalanobisThreshInit, poseMahalanobisThreshTrusted);
           const CallbackData twistCallbackData(imuTopicName + "_twist", twistUpdateVec, twistUpdateSum, differential,

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1365,7 +1365,7 @@ namespace RobotLocalization
                        false);
         if (publishMahalanobisDistance)
         {
-          mahalanobisDistancePubMap_[poseTopicName] = nhLocal_.advertise<std_msgs::Float64>(poseTopicName + "/squared_mahalanobis_dist", 20);
+          mahalanobisDistancePubMap_[poseTopicName+ "_pose"] = nhLocal_.advertise<std_msgs::Float64>(poseTopicName+ "_pose" + "/squared_mahalanobis_dist", 20);
         }
         double poseMahalanobisThresh;
         nhLocal_.param(poseTopicName + std::string("_rejection_threshold"),
@@ -1480,7 +1480,7 @@ namespace RobotLocalization
                        false);
         if (publishMahalanobisDistance)
         {
-          mahalanobisDistancePubMap_[twistTopicName] = nhLocal_.advertise<std_msgs::Float64>(twistTopicName + "/squared_mahalanobis_dist", 20);
+          mahalanobisDistancePubMap_[twistTopicName+ "_twist"] = nhLocal_.advertise<std_msgs::Float64>(twistTopicName+ "_twist" + "/squared_mahalanobis_dist", 20);
         }
         double twistMahalanobisThresh;
         nhLocal_.param(twistTopicName + std::string("_rejection_threshold"),

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -296,7 +296,7 @@ namespace RobotLocalization
     FB_DEBUG("Squared Mahalanobis is: " << sqMahalanobis << "\n" <<
               "Threshold is: " << measurement.mahalanobisThresh_*measurement.mahalanobisThresh_ << "\n" <<
               "Innovation is: " << innovationSubset << "\n" <<
-              "Innovation covariance is:\n" << innovMatInv << "\n");
+              "Innovation covariance is:\n" << invInnovCov << "\n");
     if ( measurement.publishMahalanobisDistance_)
     {
      //  Useful if inspecting a measurement from a particular source. Or on a specific dimension.

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -287,8 +287,21 @@ namespace RobotLocalization
     prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
                    kalmanGainSubset, invInnovCov, predictedMeasCovar);
 
+    double sqMahalanobis = getSquaredMahalanobisDistance(innovationSubset, invInnovCov);
+    if ( measurement.publishMahalanobisDistance_)
+    {
+     //  Useful if inspecting a measurement from a particular source. Or on a specific dimension.
+      std::map<std::string, double>& mDistMap = measurementMapPeriodicMaxSquaredMahalanobisDistance_;
+      if(auto search = mDistMap.find(measurement.topicName_); search == mDistMap.end())
+      {
+        mDistMap[measurement.topicName_] = sqMahalanobis;
+      }
+      double &mDistReference = mDistMap.at(measurement.topicName_);
+      // we filter for the max per each periodic update
+      mDistReference = std::max(mDistReference, sqMahalanobis);
+    }
     // (5) Check Mahalanobis distance of innovation
-    if (checkMahalanobisThreshold(innovationSubset, invInnovCov, measurement.mahalanobisThresh_))
+    if (checkMahalanobisThreshold(sqMahalanobis, measurement.mahalanobisThresh_))
     {
       state_.noalias() += kalmanGainSubset * innovationSubset;
 


### PR DESCRIPTION
# Publish Mahalanobis distance per input source

---

* Developer(s): @1hada 

## Description
Simply adds a publisher for the mahalanobis distance per data source. The maximum ahalanobis distance is published from the periodic update timer. The publisher can be turned on and off from by specifying the appropriate parameter within configuration files.

## Changes
Within `RosFilter`
* Adds a publisher for the maximum mahalanobis distance within a periodic loop.
* Adds a param (`*_publish_mahalanobis_distance`) for determining whether to publish the distances for that data source.

Within `FilterBase` :
* Reformats the check for the mahalanobis distance to simply check against two values and makes a dedicated method for getting the mahalanobis distance.
* Adds a method (`getCopyAndClearMahalanobisDistanceMap()`) for getting a copy of the latest set of mahalanobis distances before clearing it to reset for the next periodic loop.

The logic has been tested via bag data :
![image](https://user-images.githubusercontent.com/45742788/204574346-e302917d-a968-4a9a-a0a8-6b710054ff1e.png)


## Checklist:
- [ ] Debian Bump
- [X] Tested on bag data.
- [ ] Tested on machine.
