### PR TITLE
Improving debugging

### DIFF
--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -156,10 +156,13 @@ namespace RobotLocalization
 
   void Ekf::correct(const Measurement &measurement)
   {
+    std::ostringstream sstream;
+    sstream << std::setprecision(16) << measurement.time_;
+    std::string timeAsString = sstream.str();
     FB_DEBUG("---------------------- Ekf::correct ----------------------\n" <<
              "State is:\n" << state_ << "\n"
              "Topic is:\n" << measurement.topicName_ << "\n"
-             "Time is:\n" << measurement.time_ << "\n"
+             "Time is: " << timeAsString << "\n"
              "Measurement is:\n" << measurement.measurement_ << "\n"
              "Measurement topic name is:\n" << measurement.topicName_ << "\n\n"
              "Measurement covariance is:\n" << measurement.covariance_ << "\n");
@@ -211,9 +214,12 @@ namespace RobotLocalization
 
   void Ekf::predict(const double referenceTime, const double delta)
   {
+    std::ostringstream sstream;
+    sstream << std::setprecision(16) << referenceTime;
+    std::string timeAsString = sstream.str();
     FB_DEBUG("---------------------- Ekf::predict ----------------------\n" <<
              "delta is " << delta << "\n" <<
-             "end time is " << referenceTime << "\n" <<
+             "end time is " << timeAsString << "\n" <<
              "state is " << state_ << "\n");
 
     double roll = state_(StateMemberRoll);

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -159,6 +159,7 @@ namespace RobotLocalization
     FB_DEBUG("---------------------- Ekf::correct ----------------------\n" <<
              "State is:\n" << state_ << "\n"
              "Topic is:\n" << measurement.topicName_ << "\n"
+             "Time is:\n" << measurement.time_ << "\n"
              "Measurement is:\n" << measurement.measurement_ << "\n"
              "Measurement topic name is:\n" << measurement.topicName_ << "\n\n"
              "Measurement covariance is:\n" << measurement.covariance_ << "\n");
@@ -212,6 +213,7 @@ namespace RobotLocalization
   {
     FB_DEBUG("---------------------- Ekf::predict ----------------------\n" <<
              "delta is " << delta << "\n" <<
+             "end time is " << referenceTime << "\n" <<
              "state is " << state_ << "\n");
 
     double roll = state_(StateMemberRoll);

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -489,6 +489,8 @@ namespace RobotLocalization
       return false;
     }
 
+    FB_DEBUG("Innovation mahalanobis distance test passed. Squared Mahalanobis is: " << sqMahalanobis << "\n");
+
     return true;
   }
 }  // namespace RobotLocalization

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -268,6 +268,8 @@ namespace RobotLocalization
   {
     FB_DEBUG("---------------------- Ukf::correct ----------------------\n" <<
              "State is:\n" << state_ <<
+             "\nTopic is:\n" << measurement.topicName_ <<
+             "\nTime is:\n" << measurement.time_ <<
              "\nMeasurement is:\n" << measurement.measurement_ <<
              "\nMeasurement covariance is:\n" << measurement.covariance_ << "\n");
     
@@ -317,6 +319,7 @@ namespace RobotLocalization
   {
     FB_DEBUG("---------------------- Ukf::predict ----------------------\n" <<
              "delta is " << delta <<
+             "end time is " << referenceTime << "\n" <<
              "\nstate is " << state_ << "\n");
 
     prepareControl(referenceTime, delta);

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -266,10 +266,13 @@ namespace RobotLocalization
 
   void Ukf::correct(const Measurement &measurement)
   {
+    std::ostringstream sstream;
+    sstream << std::setprecision(16) << measurement.time_;
+    std::string timeAsString = sstream.str();
     FB_DEBUG("---------------------- Ukf::correct ----------------------\n" <<
              "State is:\n" << state_ <<
              "\nTopic is:\n" << measurement.topicName_ <<
-             "\nTime is:\n" << measurement.time_ <<
+             "\nTime is:\n" << timeAsString <<
              "\nMeasurement is:\n" << measurement.measurement_ <<
              "\nMeasurement covariance is:\n" << measurement.covariance_ << "\n");
     
@@ -317,9 +320,12 @@ namespace RobotLocalization
 
   void Ukf::predict(const double referenceTime, const double delta)
   {
+    std::ostringstream sstream;
+    sstream << std::setprecision(16) << referenceTime;
+    std::string timeAsString = sstream.str();
     FB_DEBUG("---------------------- Ukf::predict ----------------------\n" <<
              "delta is " << delta <<
-             "end time is " << referenceTime << "\n" <<
+             "end time is " << timeAsString << "\n" <<
              "\nstate is " << state_ << "\n");
 
     prepareControl(referenceTime, delta);


### PR DESCRIPTION
## Adding Debugging Information into Log

Author: @chacalnoir 

Added the time of measurements and prediction steps and the mahalanobis distance when passing into the log data so we can parse and use during analysis.
Changes
- Added time of measurements and prediction steps into the log data
- Added the mahalanobis distance of innovations when they pass into the log

Tests:
[] Tested in simulation