### PR TITLE
use trusted thresholds by populating *TopicName

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-robot-localization (102.7.3-focal10) focal; urgency=medium
+
+  * use trusted thresholds by populating *TopicName.
+
+ -- Jonathan Sanabria <jonathan@greenzie.com>  Mon, 05 Dec 2022 16:18:57 -0500
+
 ros-noetic-robot-localization (102.7.3-focal9) focal; urgency=medium
 
   * Adding publisher for mahalanobis distance via configuration.

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -273,11 +273,11 @@ template<class T> class RosFilter
 
     //! @brief Callback method for receiving all trusted sensor data
     //! @param[in] msg - The ROS Bool message to take in.
-    //! @param[in] topicName - The topic name for the sensor data that is trusted/untrusted
+    //! @param[in] topicNames - Topic name(s) for the sensor data that is trusted/untrusted, (odom|pose|twist|imu)[0-9]
     //!
     //! This method receives trusted sensor information for handling rejection thresholds
     //!
-    void trustedSensorCallback(const std_msgs::Bool::ConstPtr &msg, const std::string &topicName);
+    void trustedSensorCallback(const std_msgs::Bool::ConstPtr &msg, const std::vector<std::string> &topicNames);
 
     //! @brief Processes all measurements in the measurement queue, in temporal order
     //!

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2191,7 +2191,6 @@ namespace RobotLocalization
           {
             // Trusted source
             rejectionThreshold = callbackData.rejectionThresholdTrusted_;
-            ROS_INFO("IS USING rejectionThreshold == %f", rejectionThreshold);// FOR TESTING
           }
           if(sourceData_[topicName].bias_valid_)
           {
@@ -2271,8 +2270,6 @@ namespace RobotLocalization
     {
       for(auto &item : sourceData_)
       {
-        ROS_WARN_STREAM("periodicUpdate item.first" << item.first);// FOR TESTING
-
         if((trusted_timeout_ > 0.0) && 
           (item.second.trusted_) &&
           (secCurTime > (item.second.last_trusted_s_ + trusted_timeout_)))

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -660,23 +660,26 @@ namespace RobotLocalization
 
   template<typename T>
   void RosFilter<T>::trustedSensorCallback(const std_msgs::Bool::ConstPtr &msg,
-                                           const std::string &topicName)
+                                           const std::vector<std::string> &topicNames)
   {
-    // RF_VERBOSE provides this info in the debug file inline with the received and
-    //  and processed data, so is highly useful
-    RF_VERBOSE("Received trusted sensor data for topic " << topicName <<
-      " with trusted " << ((msg->data) ? "true\n" : "false\n"));
-    // If this information is to be provided via a ROS stream, do so from the provider
-    // Pass it in/save it all
-    if(sourceData_.find(topicName) == sourceData_.end())
+    for ( auto topicName : topicNames)
     {
-      RF_VERBOSE("Adding trusted sensor source data for topic " << topicName << "\n");
-      // Create it
-      sourceData_.emplace(topicName, SourceData());
+      // RF_VERBOSE provides this info in the debug file inline with the received and
+      //  and processed data, so is highly useful
+      RF_VERBOSE("Received trusted sensor data for topic " << topicName <<
+        " with trusted " << ((msg->data) ? "true\n" : "false\n"));
+      // If this information is to be provided via a ROS stream, do so from the provider
+      // Pass it in/save it all
+      if(sourceData_.find(topicName) == sourceData_.end())
+      {
+        RF_VERBOSE("Adding trusted sensor source data for topic " << topicName << "\n");
+        // Create it
+        sourceData_.emplace(topicName, SourceData());
+      }
+      // Save the data
+      sourceData_[topicName].trusted_ = msg->data;
+      sourceData_[topicName].last_trusted_s_ = ros::Time::now().toSec();
     }
-    // Save the data
-    sourceData_[topicName].trusted_ = msg->data;
-    sourceData_[topicName].last_trusted_s_ = ros::Time::now().toSec();
   }
 
   template<typename T>
@@ -1262,10 +1265,11 @@ namespace RobotLocalization
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayOdom)));
           
           // Subscribe to trusted data
+          std::vector<std::string> topicNames = {odomTopicName + "_pose", odomTopicName + "_twist"};
           topicSubs_.push_back(
             nh_.subscribe<std_msgs::Bool>(odomTopic + std::string("/trusted"), odomQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                odomTopicName), ros::VoidPtr(),
+                topicNames), ros::VoidPtr(),
                 ros::TransportHints().tcpNoDelay(nodelayOdom)));
         }
         else
@@ -1414,10 +1418,11 @@ namespace RobotLocalization
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayPose)));
           
           // Subscribe to trusted data
+          std::vector<std::string> topicNames = {poseTopicName + "_pose"};
           topicSubs_.push_back(
             nh_.subscribe<std_msgs::Bool>(poseTopic + std::string("/trusted"), poseQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                poseTopic), ros::VoidPtr(),
+                topicNames), ros::VoidPtr(),
                 ros::TransportHints().tcpNoDelay(nodelayPose)));
 
           if (differential)
@@ -1524,10 +1529,11 @@ namespace RobotLocalization
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayTwist)));
 
           // Subscribe to trusted data
+          std::vector<std::string> topicNames = {twistTopicName + "_twist"};
           topicSubs_.push_back(
             nh_.subscribe<std_msgs::Bool>(twistTopic + std::string("/trusted"), twistQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                twistTopic), ros::VoidPtr(),
+                topicNames), ros::VoidPtr(),
                 ros::TransportHints().tcpNoDelay(nodelayTwist)));
 
           twistVarCounts[StateMemberVx] += twistUpdateVec[StateMemberVx];
@@ -1753,10 +1759,11 @@ namespace RobotLocalization
                 accelCallbackData), ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayImu)));
 
           // Subscribe to trusted data
+          std::vector<std::string> topicNames = {imuTopicName + "_pose", imuTopicName + "_twist", imuTopicName + "_acceleration"};
           topicSubs_.push_back(
             nh_.subscribe<std_msgs::Bool>(imuTopic + std::string("/trusted"), imuQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
-                imuTopic), ros::VoidPtr(),
+                topicNames), ros::VoidPtr(),
                 ros::TransportHints().tcpNoDelay(nodelayImu)));
         }
         else
@@ -2184,6 +2191,7 @@ namespace RobotLocalization
           {
             // Trusted source
             rejectionThreshold = callbackData.rejectionThresholdTrusted_;
+            ROS_INFO("IS USING rejectionThreshold == %f", rejectionThreshold);// FOR TESTING
           }
           if(sourceData_[topicName].bias_valid_)
           {
@@ -2263,6 +2271,8 @@ namespace RobotLocalization
     {
       for(auto &item : sourceData_)
       {
+        ROS_WARN_STREAM("periodicUpdate item.first" << item.first);// FOR TESTING
+
         if((trusted_timeout_ > 0.0) && 
           (item.second.trusted_) &&
           (secCurTime > (item.second.last_trusted_s_ + trusted_timeout_)))

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1418,7 +1418,7 @@ namespace RobotLocalization
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayPose)));
           
           // Subscribe to trusted data
-          std::vector<std::string> topicNames = {poseTopicName + "_pose"};
+          std::vector<std::string> topicNames = {poseTopicName};
           topicSubs_.push_back(
             nh_.subscribe<std_msgs::Bool>(poseTopic + std::string("/trusted"), poseQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,
@@ -1529,7 +1529,7 @@ namespace RobotLocalization
               ros::VoidPtr(), ros::TransportHints().tcpNoDelay(nodelayTwist)));
 
           // Subscribe to trusted data
-          std::vector<std::string> topicNames = {twistTopicName + "_twist"};
+          std::vector<std::string> topicNames = {twistTopicName};
           topicSubs_.push_back(
             nh_.subscribe<std_msgs::Bool>(twistTopic + std::string("/trusted"), twistQueueSize,
               boost::bind(&RosFilter<T>::trustedSensorCallback, this, _1,


### PR DESCRIPTION
robot_localization : to use trusted thresholds by populating *TopicName

`[odom|imu|pose|twist]TopicName` is what actually gets passed into the callbacks since it is what is in the `CallbackData [pose|twist|acceleration]CallbackData`. In order to leverage the already made `trustedSensorCallback(..)` method, we can make a vector of all the callback data topic names which we anticipate, and allow the odom/imu source to populate those with a for loop.
