### PR TITLE
adding ImuBiasValidity msg and publishing validity result from update BiasEstimate(..).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,13 @@ roslint_cpp()
 ###################################
 ## catkin specific configuration ##
 ###################################
+# Generate messages in the 'msg' folder
+add_message_files(
+  DIRECTORY msg
+  FILES
+    ImuBiasValidity.msg
+)
+
 add_service_files(
   FILES
     GetState.srv

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-robot-localization (102.7.3-focal11) focal; urgency=medium
+
+  * Adding message for IMU data validity check.
+
+ -- Jonathan Sanabria <jonathan@greenzie.com>  Tue, 27 Dec 2022 11:43:07 -0500
+
 ros-noetic-robot-localization (102.7.3-focal10) focal; urgency=medium
 
   * use trusted thresholds by populating *TopicName.

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -40,6 +40,7 @@
 
 #include <robot_localization/SetPose.h>
 #include <robot_localization/ToggleFilterProcessing.h>
+#include <robot_localization/ImuBiasValidity.h>
 
 #include <ros/ros.h>
 #include <std_msgs/Float64.h>
@@ -835,6 +836,10 @@ template<class T> class RosFilter
     //! regex example == /odometry_outname/(odom|pose|twist|imu)[0-9]_(pose|twist|acceleration)/squared_mahalanobis_dist
     //!
     std::map<std::string, ros::Publisher> mahalanobisDistancePubMap_;
+
+    //! @brief A map of publishers per each imu topic with the param set for publishing
+    //!
+    std::map<std::string, ros::Publisher> imuDataValidityPubMap_;
 
     //! @brief rejected measurements topics publisher
     //!

--- a/msg/ImuBiasValidity.msg
+++ b/msg/ImuBiasValidity.msg
@@ -1,0 +1,3 @@
+bool roll
+bool pitch
+bool yaw

--- a/package.xml
+++ b/package.xml
@@ -39,7 +39,6 @@
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</build_depend>
   <build_depend>roslint</build_depend>
-  <build_export_depend>message_runtime</build_export_depend>
 
   <exec_depend>message_runtime</exec_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -39,6 +39,7 @@
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</build_depend>
   <build_depend>roslint</build_depend>
+  <build_export_depend>message_runtime</build_export_depend>
 
   <exec_depend>message_runtime</exec_depend>
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1850,6 +1850,7 @@ namespace RobotLocalization
                   boost::bind(&RosFilter<T>::imuMagnetometerValidityCallback, this, _1,
                     dynamic_correction_topic), ros::VoidPtr(),
                     ros::TransportHints().tcpNoDelay(nodelayImu)));
+              imuDataValidityPubMap_[dynamic_correction_topic] = nhLocal_.advertise<robot_localization::ImuBiasValidity>(dynamic_correction_topic+"/bias_estimator_validity", 20);
             }
           }
         }
@@ -3421,6 +3422,13 @@ namespace RobotLocalization
               can_update = false;
             }
           }
+
+          // publish validity of axis based on whether bias estimator updated the bias
+          robot_localization::ImuBiasValidity estimator_validity_msg;
+          estimator_validity_msg.roll = is_bias_valid[0];
+          estimator_validity_msg.pitch =  is_bias_valid[1];
+          estimator_validity_msg.yaw =  is_bias_valid[2];
+          imuDataValidityPubMap_[topicName].publish(estimator_validity_msg);
 
           if(can_update == true)
           {


### PR DESCRIPTION



Simply adds a new msg and publishes it per imu topic so that the result from the bias estimator validity check can be processed by nodes outside of the `robot_localization` stack.