### PR TITLE
Jonathansanabria/fail safe gps reintegration into ekf/sc 25321

### DIFF
--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -364,6 +364,12 @@ class FilterBase
     //!
     void setSensorTimeout(const double sensorTimeout);
 
+    //! @brief Manually sets the filter's state using a Measurement's relevant fields
+    //!
+    //! @param[in] state - The relevant measurement fields as the filter's current state
+    //!
+  void setStateFromMeasurement(const Measurement &measurement);
+
     //! @brief Manually sets the filter's state
     //!
     //! @param[in] state - The state to set as the filter's current state

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -280,6 +280,14 @@ template<class T> class RosFilter
     //!
     void trustedSensorCallback(const std_msgs::Bool::ConstPtr &msg, const std::vector<std::string> &topicNames);
 
+    //! @brief Callback method for receiving requests for using the measurement state
+    //! @param[in] msg - The ROS Bool message to take in.
+    //! @param[in] topicNames - Topic name(s) for the sensor data that is to be used as state.
+    //!
+    //! This method receives requests to use the applicable states from a measurement as the filter state
+    //!
+  void setMeasurementAsStateCallback(const std_msgs::Bool::ConstPtr &msg, const std::vector<std::string> &topicNames);
+
     //! @brief Processes all measurements in the measurement queue, in temporal order
     //!
     //! @param[in] currentTime - The time at which to carry out integration (the current time)

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -280,13 +280,12 @@ template<class T> class RosFilter
     //!
     void trustedSensorCallback(const std_msgs::Bool::ConstPtr &msg, const std::vector<std::string> &topicNames);
 
-    //! @brief Callback method for receiving requests for using the measurement state
-    //! @param[in] msg - The ROS Bool message to take in.
-    //! @param[in] topicNames - Topic name(s) for the sensor data that is to be used as state.
+    //! @brief Callback method for receiving a signal to use the measurements as state
+    //! @param[in] msg - The ROS String message which has the data source name (odom|pose|twist|imu)[0-9].
     //!
     //! This method receives requests to use the applicable states from a measurement as the filter state
     //!
-  void setMeasurementAsStateCallback(const std_msgs::Bool::ConstPtr &msg, const std::vector<std::string> &topicNames);
+  void setMeasurementAsStateCallback(const std_msgs::String::ConstPtr &msg);
 
     //! @brief Processes all measurements in the measurement queue, in temporal order
     //!
@@ -637,6 +636,10 @@ template<class T> class RosFilter
     //!
     double bias_timeout_;
 
+    //! @brief Timeout for how long to use a data source as state, must be >= 0
+    //!
+    double set_measurement_as_state_measurement_timeout_s_;
+
     //! @brief What is the acceleration in Z due to gravity (m/s^2)? Default is +9.80665.
     //!
     double gravitationalAcc_;
@@ -750,6 +753,10 @@ template<class T> class RosFilter
     //! @brief Holds information about data sources
     //!
     std::map<std::string, SourceData> sourceData_;
+
+    //! @brief Holds information about data sources to use as the state. key is the data source, val is time of request
+    //!
+    std::map<std::string, double> sourceDataAsStateMap_;
 
     //! @brief The most recent control input
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -638,7 +638,7 @@ template<class T> class RosFilter
 
     //! @brief Timeout for how long to use a data source as state, must be >= 0
     //!
-    double set_measurement_as_state_measurement_timeout_s_;
+    double set_measurement_as_state_timeout_s_;
 
     //! @brief What is the acceleration in Z due to gravity (m/s^2)? Default is +9.80665.
     //!

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -427,7 +427,6 @@ namespace RobotLocalization
 
   void FilterBase::setStateFromMeasurement(const Measurement &measurement)
   {
-    // FOR TESTING 3 -- cleanest usage for state set
     std::vector<size_t> updateIndices;
     // initialize using the most recent state
     Eigen::VectorXd state(state_);

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -425,6 +425,21 @@ namespace RobotLocalization
     sensorTimeout_ = sensorTimeout;
   }
 
+  void FilterBase::setStateFromMeasurement(const Measurement &measurement)
+  {
+    // FOR TESTING 3 -- cleanest usage for state set
+    std::vector<size_t> updateIndices;
+    // initialize using the most recent state
+    Eigen::VectorXd state(state_);
+    // update state on relevant measurement states
+    getUpdateIndices(measurement, updateIndices);
+    for (int i : updateIndices)
+    {
+      state(i) = measurement.measurement_(i);
+    }
+    setState(state);
+  }
+
   void FilterBase::setState(const Eigen::VectorXd &state)
   {
     state_ = state;

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -683,28 +683,13 @@ namespace RobotLocalization
   }
 
   template<typename T>
-  void RosFilter<T>::setMeasurementAsStateCallback(const std_msgs::Bool::ConstPtr &msg,
-                                           const std::vector<std::string> &topicNames)
+  void RosFilter<T>::setMeasurementAsStateCallback(const std_msgs::String::ConstPtr &msg)
   {
     // FOR TESTING 1
-    for ( auto topicName : topicNames)
-    {
-      // RF_VERBOSE provides this info in the debug file inline with the received and
-      //  and processed data, so is highly useful
-      RF_VERBOSE("Received call to set the available measurements from " << topicName <<
-        " to be used as the state " << ((msg->data) ? "true\n" : "false\n"));
-      // If this information is to be provided via a ROS stream, do so from the provider
-      // Pass it in/save it all
-      if(sourceData_.find(topicName) == sourceData_.end())
-      {
-        RF_VERBOSE("Adding trusted sensor source data for topic " << topicName << "\n");
-        // Create it
-        sourceData_.emplace(topicName, SourceData());
-      }
-      // Save the data
-      sourceData_[topicName].trusted_ = msg->data;
-      sourceData_[topicName].last_trusted_s_ = ros::Time::now().toSec();
-    }
+    // RF_VERBOSE provides this info in the debug file inline with the received and
+    //  and processed data, so is highly useful
+    RF_VERBOSE("Received call to set the available measurements from " << msg->data << " to be used as the state.");
+    sourceDataAsStateMap_[msg->data] = ros::Time::now().toSec();
   }
 
   template<typename T>
@@ -773,12 +758,14 @@ namespace RobotLocalization
           restoredMeasurementCount--;
         }
         // FOR TESTING 2 -- check for if we should be using the measurement as state
-        /*
-        if( measurement.flaggedToBeSetAsState )
+        for ( auto& request : sourceDataAsStateMap_)
         {
-          filter_.setStateFromMeasurement(*(measurement.get()));
+          if ((measurement->topicName_).find(request.first) != std::string::npos)
+          {
+            // match found so now we set the state from the measurement
+            filter_.setStateFromMeasurement(*(measurement.get()));
+          }
         }
-        */
         // This will call predict and, if necessary, correct
         filter_.processMeasurement(*(measurement.get()));
 
@@ -2106,6 +2093,15 @@ namespace RobotLocalization
 
       filter_.setEstimateErrorCovariance(initialEstimateErrorCovariance);
     }
+
+    // FOR TESTING 0
+    // Add callback which allows setting any applicable measurement fields as the new filter state 
+    int setMeasurementAsStateQueueSize = 1;
+    nhLocal_.param("set_measurement_as_state_queue_size", setMeasurementAsStateQueueSize, 1);
+    // get the timeout for the signal which determines whether to use the measurement's fields as the state
+    nhLocal_.param("set_measurement_as_state_timeout_s", set_measurement_as_state_measurement_timeout_s_, 0.0);
+    topicSubs_.push_back( nh_.subscribe<std_msgs::String>("set_measurement_as_state", setMeasurementAsStateQueueSize,
+    boost::bind(&RosFilter<T>::setMeasurementAsStateCallback, this, _1), ros::VoidPtr()));
   }
 
   template<typename T>

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -685,7 +685,6 @@ namespace RobotLocalization
   template<typename T>
   void RosFilter<T>::setMeasurementAsStateCallback(const std_msgs::String::ConstPtr &msg)
   {
-    // FOR TESTING 1
     // RF_VERBOSE provides this info in the debug file inline with the received and
     //  and processed data, so is highly useful
     RF_VERBOSE("Received call to set the available measurements from " << msg->data << " to be used as the state.");
@@ -757,15 +756,27 @@ namespace RobotLocalization
           filter_.setControl(measurement->latestControl_, measurement->latestControlTime_);
           restoredMeasurementCount--;
         }
-        // FOR TESTING 2 -- check for if we should be using the measurement as state
+        std::vector<std::string> erase_vector;
         for ( auto& request : sourceDataAsStateMap_)
         {
+          bool request_timed_out = set_measurement_as_state_timeout_s_ < (currentTime.toSec()-request.second);
+          if(request_timed_out)
+          {
+            // prevent node from crashing by erasing elements while iterating through them
+            erase_vector.push_back(request.first);
+            continue;
+          }
           if ((measurement->topicName_).find(request.first) != std::string::npos)
           {
             // match found so now we set the state from the measurement
             filter_.setStateFromMeasurement(*(measurement.get()));
           }
         }
+        for ( auto& request_source : erase_vector)
+        {
+          sourceDataAsStateMap_.erase(request_source);
+        }
+
         // This will call predict and, if necessary, correct
         filter_.processMeasurement(*(measurement.get()));
 
@@ -2094,13 +2105,12 @@ namespace RobotLocalization
       filter_.setEstimateErrorCovariance(initialEstimateErrorCovariance);
     }
 
-    // FOR TESTING 0
     // Add callback which allows setting any applicable measurement fields as the new filter state 
     int setMeasurementAsStateQueueSize = 1;
     nhLocal_.param("set_measurement_as_state_queue_size", setMeasurementAsStateQueueSize, 1);
     // get the timeout for the signal which determines whether to use the measurement's fields as the state
-    nhLocal_.param("set_measurement_as_state_timeout_s", set_measurement_as_state_measurement_timeout_s_, 0.0);
-    topicSubs_.push_back( nh_.subscribe<std_msgs::String>("set_measurement_as_state", setMeasurementAsStateQueueSize,
+    nhLocal_.param("set_measurement_as_state_timeout_s", set_measurement_as_state_timeout_s_, 0.0);
+    topicSubs_.push_back( nhLocal_.subscribe<std_msgs::String>("set_measurement_as_state", setMeasurementAsStateQueueSize,
     boost::bind(&RosFilter<T>::setMeasurementAsStateCallback, this, _1), ros::VoidPtr()));
   }
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -683,6 +683,31 @@ namespace RobotLocalization
   }
 
   template<typename T>
+  void RosFilter<T>::setMeasurementAsStateCallback(const std_msgs::Bool::ConstPtr &msg,
+                                           const std::vector<std::string> &topicNames)
+  {
+    // FOR TESTING 1
+    for ( auto topicName : topicNames)
+    {
+      // RF_VERBOSE provides this info in the debug file inline with the received and
+      //  and processed data, so is highly useful
+      RF_VERBOSE("Received call to set the available measurements from " << topicName <<
+        " to be used as the state " << ((msg->data) ? "true\n" : "false\n"));
+      // If this information is to be provided via a ROS stream, do so from the provider
+      // Pass it in/save it all
+      if(sourceData_.find(topicName) == sourceData_.end())
+      {
+        RF_VERBOSE("Adding trusted sensor source data for topic " << topicName << "\n");
+        // Create it
+        sourceData_.emplace(topicName, SourceData());
+      }
+      // Save the data
+      sourceData_[topicName].trusted_ = msg->data;
+      sourceData_[topicName].last_trusted_s_ = ros::Time::now().toSec();
+    }
+  }
+
+  template<typename T>
   void RosFilter<T>::integrateMeasurements(const ros::Time &currentTime)
   {
     const double currentTimeSec = currentTime.toSec();
@@ -747,7 +772,13 @@ namespace RobotLocalization
           filter_.setControl(measurement->latestControl_, measurement->latestControlTime_);
           restoredMeasurementCount--;
         }
-
+        // FOR TESTING 2 -- check for if we should be using the measurement as state
+        /*
+        if( measurement.flaggedToBeSetAsState )
+        {
+          filter_.setStateFromMeasurement(*(measurement.get()));
+        }
+        */
         // This will call predict and, if necessary, correct
         filter_.processMeasurement(*(measurement.get()));
 


### PR DESCRIPTION
# fail safe gps reintegration into ekf

---

* Ticket: [APPLICABLE SHORTCUT_TICKET](https://app.shortcut.com/greenzie/story/25321/fail-safe-gps-reintegration-into-ekf)
* Developer(s): @1hada

## Description
Adds a callback that update the applicable filter states to match a sensor's fields.

- this is intended to help systems where a measurement source should be used, but the filter's state is not close to the measurement source.

## Changes
Brief description of what changes inside the repo

* Adds one new callback `setMeasurementAsStateCallback` per filter which accepts a string that represents a data source name. The new callback will update a map which will search measurement names with a substring match. If there is a match, then the applicable data will be used as the new filter state.
* Adds a method `setStateFromMeasurement` which assigns the filter state to match a measurements applicable fields.
* Adds one new param per filter `set_measurement_as_state_timeout_s_` which determines how old the measurement can be in order for us to use it in the state update.
* Adds a new member variable `sourceDataAsStateMap_` which relates the data source with the time the request is received in order to determine whether to use that data request as the state.

![image](https://user-images.githubusercontent.com/45742788/215601909-01b7cf82-2268-4be3-a8d3-99f9414fa07a.png)



## Checklist:
- [X] Tested PR in simulation.

