### PR TITLE
Updates to better estimate the yaw variance

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-robot-localization (102.7.3-focal13) focal; urgency=medium
+
+  * Updated yaw variance estimation
+
+ -- Joel <joel@greenzie.com>  Tue, 28 Mar 2023 16:47:13 -0400
+
 ros-noetic-robot-localization (102.7.3-focal12) focal; urgency=medium
 
   * Moved static integral type definition outside of class to fix debug

--- a/include/robot_localization/ros_filter_bias_estimator.h
+++ b/include/robot_localization/ros_filter_bias_estimator.h
@@ -35,9 +35,10 @@ class RosFilterBiasEstimator {
                                const double max_variance,
                                const double alpha,
                                const double max_divergence = -1.0,
-                               const int max_num_divergences = 0,
+                               const int16_t max_num_divergences = 0,
                                const double initial_delay = 0.0,
-                               const bool is_valid = false);
+                               const bool is_valid = false,
+                               const uint16_t num_values_variance_estimation = 30);
     
         RosFilterBiasEstimator(const RosFilterBiasEstimator& right);
 
@@ -107,7 +108,7 @@ class RosFilterBiasEstimator {
             }
         }
 
-        void set_max_num_divergences(int max_num) { max_num_divergences_ = max_num; }
+        void set_max_num_divergences(int16_t max_num) { max_num_divergences_ = max_num; }
         int get_max_num_divergences() const { return max_num_divergences_; }
         void set_min_speed(double min_speed) { min_speed_ = min_speed; }
         double get_min_speed() const { return min_speed_; }
@@ -127,6 +128,8 @@ class RosFilterBiasEstimator {
         bool is_using_data() const { return using_data_; }
         void set_initial_delay(double initial_delay) { initial_delay_ = initial_delay; }
         double get_initial_delay() const { return initial_delay_; }
+        void set_num_values_variance_estimate(uint16_t num_values ) { num_values_variance_estimation_ = num_values; }
+        uint16_t get_num_values_variance_estimate() { return num_values_variance_estimation_; }
     private:
         // Time of last state received in seconds
         double uncorrected_state_received_s_{0.0};
@@ -152,7 +155,7 @@ class RosFilterBiasEstimator {
         double min_speed_{0.0};
 
         // Maximum number of divergences before no longer trying to correct. 0 means infinite.
-        int max_num_divergences_{ 0 };
+        int16_t max_num_divergences_{ 0 };
 
         // The maximum variance at which to apply corrections
         double max_orientation_variance_{0.0};
@@ -170,7 +173,7 @@ class RosFilterBiasEstimator {
         bool using_data_{false};
 
         // Whether no longer trying again
-        int num_exceeded_max_divergence_{ 0 };
+        int32_t num_exceeded_max_divergence_{ 0 };
 
         // Initial delay assuming uncorrected KF yaw estimate may be incorrect for a bit
         double initial_delay_{ 0.0 };
@@ -178,11 +181,20 @@ class RosFilterBiasEstimator {
         // For handling the initial delay
         double start_time_{ 0.0 };
 
+        // For estimating the bias variance
+        uint16_t num_values_variance_estimation_{ 30 };
+
+        // Current slot for adding data to the estimation differences vector
+        uint16_t current_variance_estimation_slot_{ 0 };
+
+        // To hold the data for the variance checks
+        std::vector<Eigen::Vector3d> estimate_differences_;
+
         // To avoid constantly checking time differences
         bool initial_delay_met_{ false };
 
         // Handling the times for the divergence test to determine whether it is valid
-        int divergence_test_counter_[BIAS_ESTIMATOR_ESTIMATION_AXES] = {-1, -1, -1};
+        int32_t divergence_test_counter_[BIAS_ESTIMATOR_ESTIMATION_AXES] = {-1, -1, -1};
         double divergence_test_steps_[BIAS_ESTIMATOR_ESTIMATION_AXES] = {0, 0, 0};
 
         // Whether the orientation offset has been set for future use.

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -509,10 +509,10 @@ namespace RobotLocalization
     double threshold = nsigmas*nsigmas;
     if (sqMahalanobis >= threshold)
     {
-      FB_DEBUG("Innovation mahalanobis distance test failed.");
+      FB_DEBUG("Innovation mahalanobis distance test failed.\n");
       return false;
     }
-    FB_DEBUG("Innovation mahalanobis distance test passed.");
+    FB_DEBUG("Innovation mahalanobis distance test passed.\n");
     return true;
   }
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1833,6 +1833,10 @@ namespace RobotLocalization
               double initial_delay = 0.0;  // Default no initial delay
               nhLocal_.param(correction_initial_delay, initial_delay, initial_delay);
 
+              std::string num_values_variance_estimation_str = dynamic_magnetometer_correction + std::string("_num_values_variance_estimation");
+              int num_values_variance_estimation = 30;  // Default to 1 sec at 30hz
+              nhLocal_.param(num_values_variance_estimation_str, num_values_variance_estimation, num_values_variance_estimation);
+
               std::string correction_alpha = dynamic_magnetometer_correction + std::string("_alpha");
               double alpha = 0.0;  // Full reliance on new measurement by default
               nhLocal_.param(correction_alpha, alpha, alpha);
@@ -1855,7 +1859,7 @@ namespace RobotLocalization
               imuDynamicCorrectionData_.insert(std::pair<std::string const, RosFilterBiasEstimator>(
                 dynamic_correction_topic, RosFilterBiasEstimator(min_speed, max_variance, alpha,
                 max_divergence, max_exceeding, initial_delay,
-                false)));  // Default to invalid unless confirmed via an external system
+                false, static_cast<int16_t>(num_values_variance_estimation))));  // Default to invalid unless confirmed via an external system
               // Set the dynamic corrections axes
               std::vector<bool> dynamic_correction_axes;
               dynamic_correction_axes.push_back((poseUpdateVec[StateMemberRoll] > 0) ? true : false);

--- a/src/ros_filter_bias_estimator.cpp
+++ b/src/ros_filter_bias_estimator.cpp
@@ -12,9 +12,10 @@ RosFilterBiasEstimator::RosFilterBiasEstimator(const double min_speed,
                                                const double max_variance,
                                                const double alpha,
                                                const double max_divergence,
-                                               const int max_num_divergences,
+                                               const int16_t max_num_divergences,
                                                const double initial_delay,
-                                               const bool is_valid) {
+                                               const bool is_valid,
+                                               const uint16_t num_values_variance_estimation) {
     set_min_speed(min_speed);
     set_max_orientation_variance(max_variance);
     set_alpha(alpha);
@@ -117,12 +118,23 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                         //  happens when the angle steps over the boundary (e.g. from -(PI-0.0001) to (PI-0.0001)). That is explained and handled in the
                         //  else condition.
                         double offset = FilterUtilities::clampRotation(uncorrected_orientation_estimate_[axis] - orientation_measurement[axis]);
+                        double difference_variance = 0.0;
+                        if(estimate_differences_.size() == num_values_variance_estimation_)
+                        {
+                            // Full data - can calculate
+                            double mean = 0.0;  // It is expecting a 0 offset between the two estimates if everything is working well.
+                            for(uint16_t counter = 0; counter < estimate_differences_.size(); counter++)
+                            {
+                                difference_variance += ::pow(::fabs(estimate_differences_[counter][axis] - mean), 2.0);
+                            }
+                            difference_variance /= static_cast<double>(num_values_variance_estimation_ - 1);
+                        }
                         if(::fabs(orientation_offset_[axis]) < 1e-9)
                         {
                             // Has not been initialized
                             orientation_offset_[axis] = offset;
                             // Should be added (+) since these are variances
-                            orientation_offset_variance_[axis] = measurement_variance[axis] + uncorrected_orientation_variance_[axis];
+                            orientation_offset_variance_[axis] = measurement_variance[axis] + uncorrected_orientation_variance_[axis] + difference_variance;
                             // Set the start time to handle the delay
                             start_time_ = time_s;
                         }
@@ -144,8 +156,7 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
 
                             // Should be added (+) since these are variances.
                             // Note that the variance is not an actual angle, so angle wrapping is not required.
-                            orientation_offset_variance_[axis] = alpha_ * orientation_offset_variance_[axis] +
-                                (1.0 - alpha_) * (uncorrected_orientation_variance_[axis] + measurement_variance[axis]);
+                            orientation_offset_variance_[axis] = uncorrected_orientation_variance_[axis] + measurement_variance[axis] + difference_variance;
                         }
                         // Handle the initial delay - may be immediate if no delay set
                         initial_delay_met_ |= ((time_s - start_time_) >= initial_delay_);
@@ -263,11 +274,27 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                 // Cannot create the pose measurement yet - there is no offset information or it has been flagged as invalid
                 is_valid[axis] = false;
             }
+
+            // Calculate the difference between estimates and place in the vector
+            double filter_difference = uncorrected_orientation_estimate_[axis] - orientation_estimate[axis];
+            if(estimate_differences_.size() <= current_variance_estimation_slot_)
+            {
+                Eigen::Vector3d new_diff(0, 0, 0);
+                estimate_differences_.push_back(new_diff);
+            }
+            estimate_differences_[current_variance_estimation_slot_][axis] = filter_difference;
         }
         else
         {
             // Not being used/estimated
             is_valid.push_back(false);
+        }
+    }
+    if(current_variance_estimation_slot_ < estimate_differences_.size())  // Don't step if no data has been added.
+    {
+        if(++current_variance_estimation_slot_ >= num_values_variance_estimation_)
+        {
+            current_variance_estimation_slot_ = 0;  // Limit to max number
         }
     }
     mtx_.unlock();

--- a/src/ros_filter_bias_estimator.cpp
+++ b/src/ros_filter_bias_estimator.cpp
@@ -41,6 +41,7 @@ RosFilterBiasEstimator::RosFilterBiasEstimator(const RosFilterBiasEstimator& rig
     set_estimation_axes(estimation_axes);
     set_max_num_divergences(right.get_max_num_divergences());
     set_initial_delay(right.get_initial_delay());
+    reset();  // Clear temporary data after the copy
 }
 
 void RosFilterBiasEstimator::reset() {
@@ -122,10 +123,9 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                         if(estimate_differences_.size() == num_values_variance_estimation_)
                         {
                             // Full data - can calculate
-                            double mean = 0.0;  // It is expecting a 0 offset between the two estimates if everything is working well.
                             for(uint16_t counter = 0; counter < estimate_differences_.size(); counter++)
                             {
-                                difference_variance += ::pow(::fabs(estimate_differences_[counter][axis] - mean), 2.0);
+                                difference_variance += ::pow(::fabs(estimate_differences_[counter][axis] - 0.0), 2.0);
                             }
                             difference_variance /= static_cast<double>(num_values_variance_estimation_ - 1);
                         }
@@ -162,8 +162,8 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                         initial_delay_met_ |= ((time_s - start_time_) >= initial_delay_);
 
                         // Calculate the difference between the uncorrected filter estimate and the corrected magnetometer value
-                        double abs_filter_to_mag_difference = ::fabs(uncorrected_orientation_estimate_[axis] -
-                            (orientation_measurement[axis] + orientation_offset_[axis]));
+                        double abs_filter_to_mag_difference = ::fabs(FilterUtilities::clampRotation(uncorrected_orientation_estimate_[axis] -
+                            (orientation_measurement[axis] + orientation_offset_[axis])));
 
                         // Dropped below limit or calculated once with no limit
                         orientation_offset_has_been_set_[axis] |= ((initial_delay_met_) &&
@@ -177,7 +177,8 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                             // The calculation is from max_divergence_ = abs_filter_difference * alpha_^(divergence_test_steps_)
                             // divergence_test_steps_ = ln(max_divergence_ / abs_filter_difference) / ln(alpha_)
                             // Note that max_divergence_ must be < abs_filter_difference since alpha_ < 1.0
-                            double abs_filter_difference = ::fabs(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]);
+                            double abs_filter_difference =
+                                ::fabs(FilterUtilities::clampRotation(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]));
                             double max_difference = std::max(abs_filter_difference, abs_filter_to_mag_difference);
                             if((max_divergence_ < max_difference) && (max_divergence_ > 0.0))
                             {
@@ -226,7 +227,8 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
                         // Run the divergence test
                         if(divergence_test_counter_[axis] >= divergence_test_steps_[axis])
                         {
-                            double abs_filter_difference = ::fabs(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]);
+                            double abs_filter_difference =
+                                ::fabs(FilterUtilities::clampRotation(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]));
                             if(abs_filter_difference > max_divergence_)
                             {
                                 // Divergence detected - cannot trust this filter's estimate of the orientation
@@ -276,7 +278,7 @@ void RosFilterBiasEstimator::updateBiasEstimate(Eigen::Vector3d &orientation_mea
             }
 
             // Calculate the difference between estimates and place in the vector
-            double filter_difference = uncorrected_orientation_estimate_[axis] - orientation_estimate[axis];
+            double filter_difference = FilterUtilities::clampRotation(uncorrected_orientation_estimate_[axis] - orientation_estimate[axis]);
             if(estimate_differences_.size() <= current_variance_estimation_slot_)
             {
                 Eigen::Vector3d new_diff(0, 0, 0);


### PR DESCRIPTION
# Improve Yaw Variance Estimation

---

* Ticket: https://app.shortcut.com/greenzie/story/26320/improve-yaw-uncertainty-estimation
* Developer(s): @IntelligentJackal 

## Description
The yaw uncertainty estimation seems to be artificially low, which causes issues integrating new position measurements. This PR helps to resolve that.
We have been assuming than a magnetometer-informed yaw measurement, using the offset provided through a low-update-rate filter of yaw from GNSS versus yaw from magnetometer, is more reliable/accurate than the EKF-based yaw estimate from GNSS. This may not be true. When the two are fairly similar (i.e. the two EKFs agree about yaw), then it is likely that this is a sound assumption. When they differ, we cannot be certain which is more accurate. Therefore, this PR uses the variance of the differences in yaw estimate between EKFs over the past second to help estimate the offset variance, improving the magnetometer measurement information. The goal is to ensure that, on mower starting to move, the yaw uncertainty is higher (if the estimates do not agree) to enable the mower to more easily accept the GNSS measurements.

## Changes
* Better estimate the yaw variance by including the variance of the difference between the EKF estimates, assuming they should be 0

## Checklist:
- [x] Tested PR in GZDEV8
- [x] Write entry on `CHANGELOG.rst`
