### PR TITLE
Reset Bias Estimator via ROS call

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-noetic-robot-localization (102.7.3-focal14) focal; urgency=medium
+
+  * Added reset to bias estimator
+
+ -- Joel <joel@greenzie.com>  Mon, 17 Apr 2023 11:49:37 -0400
+
 ros-noetic-robot-localization (102.7.3-focal13) focal; urgency=medium
 
   * Updated yaw variance estimation

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -272,6 +272,14 @@ template<class T> class RosFilter
     //!
     void imuMagnetometerValidityCallback(const std_msgs::Bool::ConstPtr &msg, const std::string &topicName);
 
+    //! @brief Callback method for bias estimator resets
+    //! @param[in] msg - The ROS EMpty message to take in.
+    //! @param[in] topicName - The topic name for the IMU message that is being dynamically corrected.
+    //!
+    //! This method receives reset commands for dynamically corrected IMU estimator resets
+    //!
+    void biasEstimatorResetCallback(const std_msgs::Empty::ConstPtr &msg, const std::string &topicName);
+
     //! @brief Callback method for receiving all trusted sensor data
     //! @param[in] msg - The ROS Bool message to take in.
     //! @param[in] topicNames - Topic name(s) for the sensor data that is trusted/untrusted, (odom|pose|twist|imu)[0-9]

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -671,6 +671,7 @@ namespace RobotLocalization
     // RF_VERBOSE provides this info in the debug file inline with the received and
     //  and processed data, so is highly useful
     RF_VERBOSE("Received bias estimator reset command for topic " << topicName);
+    ROS_INFO_STREAM("Received bias estimator reset command for topic " << topicName);
     // If this information is to be provided via a ROS stream, do so from the provider
     // Pass it in/save it all
     if(imuDynamicCorrectionData_.find(topicName) != imuDynamicCorrectionData_.end())

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -191,6 +191,12 @@ namespace RobotLocalization
     // reset filter to uninitialized state
     filter_.reset();
 
+    // Reset the yaw bias estimator
+    for(auto & estimators : imuDynamicCorrectionData_)
+    {
+      estimators.second.reset();
+    }
+
     // clear all waiting callbacks
     ros::getGlobalCallbackQueue()->clear();
   }
@@ -655,6 +661,21 @@ namespace RobotLocalization
     if(imuDynamicCorrectionData_.find(topicName) != imuDynamicCorrectionData_.end())
     {
       imuDynamicCorrectionData_[topicName].set_valid(msg->data);
+    }
+  }
+
+  template<typename T>
+  void RosFilter<T>::biasEstimatorResetCallback(const std_msgs::Empty::ConstPtr &msg,
+                                                const std::string &topicName)
+  {
+    // RF_VERBOSE provides this info in the debug file inline with the received and
+    //  and processed data, so is highly useful
+    RF_VERBOSE("Received bias estimator reset command for topic " << topicName);
+    // If this information is to be provided via a ROS stream, do so from the provider
+    // Pass it in/save it all
+    if(imuDynamicCorrectionData_.find(topicName) != imuDynamicCorrectionData_.end())
+    {
+      imuDynamicCorrectionData_[topicName].reset();
     }
   }
 
@@ -1884,6 +1905,13 @@ namespace RobotLocalization
                     dynamic_correction_topic), ros::VoidPtr(),
                     ros::TransportHints().tcpNoDelay(nodelayImu)));
               imuDataValidityPubMap_[dynamic_correction_topic] = nhLocal_.advertise<robot_localization::ImuBiasValidity>(dynamic_correction_topic+"/bias_estimator_validity", 20);
+
+              // Subscribe to resets as well
+              topicSubs_.push_back(
+                nh_.subscribe<std_msgs::Empty>(imuTopic + std::string("/reset_estimator"), imuQueueSize,
+                  boost::bind(&RosFilter<T>::biasEstimatorResetCallback, this, _1,
+                    dynamic_correction_topic), ros::VoidPtr(),
+                    ros::TransportHints().tcpNoDelay(nodelayImu)));
             }
           }
         }


### PR DESCRIPTION
# Reset Bias Estimator via ROS call

---

* Ticket: https://app.shortcut.com/greenzie/story/27031/gz50-149172gj-mower-driving-outside-of-boundary
* Developer(s): @IntelligentJackal 

## Description
The IMU bias estimator is not reset when the IMU is reset causing a direction jump that the mower assumes is correct and subsequent EKF/GNSS divergence. This fixes that issue.

## Changes
* Created new topic and linked callback to bias estimator reset.

## Checklist:
- [ ] Tested PR in `<MOWER_NAME>`
- [x] Write entry on `CHANGELOG.rst`
- [x] Tested PR in simulation
