### PR TITLE
Added precision to origin output for analyzing issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Forthcoming
 * Added local cartesian option
 * Adding Pipeline
 * Throttling GNSS Origin data warning
+* Added precision to origin output
 
 2.7.3 (2021-07-23)
 ------------------

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -931,7 +931,7 @@ namespace RobotLocalization
       utm_meridian_convergence_ = utm_meridian_convergence_degrees * NavsatConversions::RADIANS_PER_DEGREE;
     }
 
-    ROS_INFO_STREAM("Datum (latitude, longitude, altitude) is (" << std::fixed << msg->latitude << ", " <<
+    ROS_INFO_STREAM("Datum (latitude, longitude, altitude) is (" << std::fixed << std::setprecision(16) << msg->latitude << ", " <<
                     msg->longitude << ", " << msg->altitude << ")");
     ROS_INFO_STREAM("Datum " << ((use_local_cartesian_)? "Local Cartesian" : "UTM") <<
                     " coordinate is (" << std::fixed << cartesian_x << ", " << cartesian_y << ") zone " << utm_zone_);


### PR DESCRIPTION
## Overview
Author: @IntelligentJackal 

## Impact
* GZ127 had an issue in which the local-level position of the map seemed to be off. The origin point does not have enough significant digits to determine if this is true.
* This PR increases the logged origin point significant digits so we can better analyze the data.

## Description
n/a

## Testing
* Tested in simulation

## Checklist
* [x] Updated changelog.rst
* [x] Tested in simulation

