### PR TITLE
Scale GPS yaw kalman gains based on linear velocity

### DIFF
--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -81,6 +81,20 @@ struct Measurement
   // measurements.
   std::string topicName_;
 
+  // Whether to scale this measurement's heading-state correction gain as a
+  // function of vehicle speed.
+  bool speedDependentHeadingGain_;
+
+  // Speed [m/s] below which the heading correction gain is held at
+  // headingGainAtLowSpeed_.
+  double headingGainLowSpeedMps_;
+
+  // Speed [m/s] above which the heading correction gain is 1.0.
+  double headingGainHighSpeedMps_;
+
+  // Heading correction gain applied at or below headingGainLowSpeedMps_.
+  double headingGainAtLowSpeed_;
+
   // This defines which variables within this measurement
   // actually get passed into the filter. std::vector<bool>
   // is generally frowned upon, so we use ints.
@@ -109,7 +123,11 @@ struct Measurement
     mahalanobisThresh_(std::numeric_limits<double>::max()),
     mahalanobisThreshInit_(std::numeric_limits<double>::max()),
     time_(0.0),
-    topicName_("")
+    topicName_(""),
+    speedDependentHeadingGain_(false),
+    headingGainLowSpeedMps_(0.0),
+    headingGainHighSpeedMps_(0.0),
+    headingGainAtLowSpeed_(1.0)
   {
   }
 };

--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -120,6 +120,7 @@ struct Measurement
 
   Measurement() :
     latestControlTime_(0.0),
+    publishMahalanobisDistance_(false),
     mahalanobisThresh_(std::numeric_limits<double>::max()),
     mahalanobisThreshInit_(std::numeric_limits<double>::max()),
     time_(0.0),

--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -83,7 +83,7 @@ struct Measurement
 
   // Whether to scale this measurement's heading-state correction gain as a
   // function of vehicle speed.
-  bool speedDependentHeadingGain_;
+  bool isSpeedDependentHeadingGainEnabled_;
 
   // Speed [m/s] below which the heading correction gain is held at
   // headingGainAtLowSpeed_.
@@ -125,7 +125,7 @@ struct Measurement
     mahalanobisThreshInit_(std::numeric_limits<double>::max()),
     time_(0.0),
     topicName_(""),
-    speedDependentHeadingGain_(false),
+    isSpeedDependentHeadingGainEnabled_(false),
     headingGainLowSpeedMps_(0.0),
     headingGainHighSpeedMps_(0.0),
     headingGainAtLowSpeed_(1.0)

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -133,6 +133,14 @@ struct SourceData
   double last_bias_s_{-std::numeric_limits<double>::infinity()};  // Never set initially
 };
 
+struct HeadingGainSettings
+{
+  bool isEnabled{false};
+  double lowSpeedMps{0.0};
+  double highSpeedMps{0.0};
+  double gainAtLowSpeed{1.0};
+};
+
 typedef std::priority_queue<MeasurementPtr, std::vector<MeasurementPtr>, Measurement> MeasurementQueue;
 typedef std::deque<MeasurementPtr> MeasurementHistoryDeque;
 typedef std::deque<FilterStatePtr> FilterStateHistoryDeque;
@@ -763,10 +771,7 @@ template<class T> class RosFilter
 
     //! @brief Per-topic speed-dependent heading gain settings
     //!
-    std::map<std::string, bool> speedDependentHeadingGainMap_;
-    std::map<std::string, double> headingGainLowSpeedMpsMap_;
-    std::map<std::string, double> headingGainHighSpeedMpsMap_;
-    std::map<std::string, double> headingGainAtLowSpeedMap_;
+    std::map<std::string, HeadingGainSettings> headingGainSettingsMap_;
 
     //! @brief Holds information about data sources to use as the state. key is the data source, val is time of request
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -761,6 +761,13 @@ template<class T> class RosFilter
     //!
     std::map<std::string, SourceData> sourceData_;
 
+    //! @brief Per-topic speed-dependent heading gain settings
+    //!
+    std::map<std::string, bool> speedDependentHeadingGainMap_;
+    std::map<std::string, double> headingGainLowSpeedMpsMap_;
+    std::map<std::string, double> headingGainHighSpeedMpsMap_;
+    std::map<std::string, double> headingGainAtLowSpeedMap_;
+
     //! @brief Holds information about data sources to use as the state. key is the data source, val is time of request
     //!
     std::map<std::string, double> sourceDataAsStateMap_;

--- a/params/dual_ekf_navsat_example.yaml
+++ b/params/dual_ekf_navsat_example.yaml
@@ -106,6 +106,12 @@ ekf_se_map:
   odom1_nodelay: true
   odom1_differential: false
   odom1_relative: false
+  # [ADVANCED] Speed-dependent heading gain — reduces heading influence from GPS-derived pose at low speeds.
+  # See ekf_template.yaml for full parameter descriptions.
+  # odom1_pose_speed_dependent_heading_gain: false
+  # odom1_pose_heading_gain_low_speed_mps: 0.5
+  # odom1_pose_heading_gain_high_speed_mps: 1.5
+  # odom1_pose_heading_gain_at_low_speed: 0.1
 
   imu0: imu/data
   imu0_config: [false, false, false,
@@ -163,4 +169,3 @@ navsat_transform:
   publish_filtered_gps: true
   use_odometry_yaw: false
   wait_for_datum: false
-

--- a/params/dual_ekf_navsat_example.yaml
+++ b/params/dual_ekf_navsat_example.yaml
@@ -108,10 +108,10 @@ ekf_se_map:
   odom1_relative: false
   # [ADVANCED] Speed-dependent heading gain — reduces heading influence from GPS-derived pose at low speeds.
   # See ekf_template.yaml for full parameter descriptions.
-  # odom1_pose_speed_dependent_heading_gain: false
-  # odom1_pose_heading_gain_low_speed_mps: 0.5
-  # odom1_pose_heading_gain_high_speed_mps: 1.5
-  # odom1_pose_heading_gain_at_low_speed: 0.1
+  odom1_pose_speed_dependent_heading_gain: false
+  odom1_pose_heading_gain_low_speed_mps: 0.5
+  odom1_pose_heading_gain_high_speed_mps: 1.5
+  odom1_pose_heading_gain_at_low_speed: 0.1
 
   imu0: imu/data
   imu0_config: [false, false, false,

--- a/params/ekf_template.yaml
+++ b/params/ekf_template.yaml
@@ -125,13 +125,13 @@ odom0_twist_rejection_threshold: 1
 
 # [ADVANCED] Speed-dependent heading gain reduces the influence of heading from this pose source at low speeds,
 # where heading measurements from position-based sensors (e.g., GPS) are typically unreliable. When enabled, the
-# heading measurement covariance is scaled by a gain interpolated between odom0_pose_heading_gain_at_low_speed
+# Kalman gain for heading is scaled by a gain interpolated between odom0_pose_heading_gain_at_low_speed
 # (applied at or below odom0_pose_heading_gain_low_speed_mps) and 1.0 (applied at or above
 # odom0_pose_heading_gain_high_speed_mps). Only has effect when yaw is included in the sensor config.
 # odom0_pose_speed_dependent_heading_gain: false
 # odom0_pose_heading_gain_low_speed_mps: 0.5   # Speed at or below which the low-speed gain is fully applied (m/s)
 # odom0_pose_heading_gain_high_speed_mps: 1.5  # Speed at or above which gain returns to 1.0 (m/s)
-# odom0_pose_heading_gain_at_low_speed: 0.1    # Covariance scale factor at low speed; lower = less heading influence
+# odom0_pose_heading_gain_at_low_speed: 0.1    # Kalman gain scale factor at low speed; lower = less heading influence
 
 # Further input parameter examples
 odom1: example/another_odom

--- a/params/ekf_template.yaml
+++ b/params/ekf_template.yaml
@@ -123,6 +123,16 @@ odom0_relative: false
 odom0_pose_rejection_threshold: 5
 odom0_twist_rejection_threshold: 1
 
+# [ADVANCED] Speed-dependent heading gain reduces the influence of heading from this pose source at low speeds,
+# where heading measurements from position-based sensors (e.g., GPS) are typically unreliable. When enabled, the
+# heading measurement covariance is scaled by a gain interpolated between odom0_pose_heading_gain_at_low_speed
+# (applied at or below odom0_pose_heading_gain_low_speed_mps) and 1.0 (applied at or above
+# odom0_pose_heading_gain_high_speed_mps). Only has effect when yaw is included in the sensor config.
+# odom0_pose_speed_dependent_heading_gain: false
+# odom0_pose_heading_gain_low_speed_mps: 0.5   # Speed at or below which the low-speed gain is fully applied (m/s)
+# odom0_pose_heading_gain_high_speed_mps: 1.5  # Speed at or above which gain returns to 1.0 (m/s)
+# odom0_pose_heading_gain_at_low_speed: 0.1    # Covariance scale factor at low speed; lower = less heading influence
+
 # Further input parameter examples
 odom1: example/another_odom
 odom1_config: [false, false, true,
@@ -135,6 +145,10 @@ odom1_relative: true
 odom1_queue_size: 2
 odom1_pose_rejection_threshold: 2
 odom1_twist_rejection_threshold: 0.2
+# odom1_pose_speed_dependent_heading_gain: false
+# odom1_pose_heading_gain_low_speed_mps: 0.5
+# odom1_pose_heading_gain_high_speed_mps: 1.5
+# odom1_pose_heading_gain_at_low_speed: 0.1
 odom1_nodelay: false
 
 pose0: example/pose
@@ -147,6 +161,11 @@ pose0_differential: true
 pose0_relative: false
 pose0_queue_size: 5
 pose0_rejection_threshold: 2  # Note the difference in parameter name
+# [ADVANCED] Speed-dependent heading gain for pose topics (note: no '_pose_' infix, unlike odom topics)
+# pose0_speed_dependent_heading_gain: false
+# pose0_heading_gain_low_speed_mps: 0.5
+# pose0_heading_gain_high_speed_mps: 1.5
+# pose0_heading_gain_at_low_speed: 0.1
 pose0_nodelay: false
 
 twist0: example/twist
@@ -252,4 +271,3 @@ initial_estimate_covariance: [1e-9, 0,    0,    0,    0,    0,    0,    0,    0,
                               0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     1e-9, 0,    0,
                               0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    1e-9, 0,
                               0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    1e-9]
-

--- a/params/ekf_template.yaml
+++ b/params/ekf_template.yaml
@@ -145,10 +145,10 @@ odom1_relative: true
 odom1_queue_size: 2
 odom1_pose_rejection_threshold: 2
 odom1_twist_rejection_threshold: 0.2
-# odom1_pose_speed_dependent_heading_gain: false
-# odom1_pose_heading_gain_low_speed_mps: 0.5
-# odom1_pose_heading_gain_high_speed_mps: 1.5
-# odom1_pose_heading_gain_at_low_speed: 0.1
+odom1_pose_speed_dependent_heading_gain: false
+odom1_pose_heading_gain_low_speed_mps: 0.5
+odom1_pose_heading_gain_high_speed_mps: 1.5
+odom1_pose_heading_gain_at_low_speed: 0.1
 odom1_nodelay: false
 
 pose0: example/pose

--- a/params/ukf_template.yaml
+++ b/params/ukf_template.yaml
@@ -147,10 +147,10 @@ odom1_relative: true
 odom1_queue_size: 2
 odom1_pose_rejection_threshold: 2
 odom1_twist_rejection_threshold: 0.2
-# odom1_pose_speed_dependent_heading_gain: false
-# odom1_pose_heading_gain_low_speed_mps: 0.5
-# odom1_pose_heading_gain_high_speed_mps: 1.5
-# odom1_pose_heading_gain_at_low_speed: 0.1
+odom1_pose_speed_dependent_heading_gain: false
+odom1_pose_heading_gain_low_speed_mps: 0.5
+odom1_pose_heading_gain_high_speed_mps: 1.5
+odom1_pose_heading_gain_at_low_speed: 0.1
 odom1_nodelay: false
 
 pose0: example/pose

--- a/params/ukf_template.yaml
+++ b/params/ukf_template.yaml
@@ -127,13 +127,13 @@ odom0_twist_rejection_threshold: 1
 
 # [ADVANCED] Speed-dependent heading gain reduces the influence of heading from this pose source at low speeds,
 # where heading measurements from position-based sensors (e.g., GPS) are typically unreliable. When enabled, the
-# heading measurement covariance is scaled by a gain interpolated between odom0_pose_heading_gain_at_low_speed
+# Kalman gain for heading is scaled by a gain interpolated between odom0_pose_heading_gain_at_low_speed
 # (applied at or below odom0_pose_heading_gain_low_speed_mps) and 1.0 (applied at or above
 # odom0_pose_heading_gain_high_speed_mps). Only has effect when yaw is included in the sensor config.
 # odom0_pose_speed_dependent_heading_gain: false
 # odom0_pose_heading_gain_low_speed_mps: 0.5   # Speed at or below which the low-speed gain is fully applied (m/s)
 # odom0_pose_heading_gain_high_speed_mps: 1.5  # Speed at or above which gain returns to 1.0 (m/s)
-# odom0_pose_heading_gain_at_low_speed: 0.1    # Covariance scale factor at low speed; lower = less heading influence
+# odom0_pose_heading_gain_at_low_speed: 0.1    # Kalman gain scale factor at low speed; lower = less heading influence
 
 # Further input parameter examples
 odom1: example/another_odom

--- a/params/ukf_template.yaml
+++ b/params/ukf_template.yaml
@@ -125,6 +125,16 @@ odom0_relative: false
 odom0_pose_rejection_threshold: 5
 odom0_twist_rejection_threshold: 1
 
+# [ADVANCED] Speed-dependent heading gain reduces the influence of heading from this pose source at low speeds,
+# where heading measurements from position-based sensors (e.g., GPS) are typically unreliable. When enabled, the
+# heading measurement covariance is scaled by a gain interpolated between odom0_pose_heading_gain_at_low_speed
+# (applied at or below odom0_pose_heading_gain_low_speed_mps) and 1.0 (applied at or above
+# odom0_pose_heading_gain_high_speed_mps). Only has effect when yaw is included in the sensor config.
+# odom0_pose_speed_dependent_heading_gain: false
+# odom0_pose_heading_gain_low_speed_mps: 0.5   # Speed at or below which the low-speed gain is fully applied (m/s)
+# odom0_pose_heading_gain_high_speed_mps: 1.5  # Speed at or above which gain returns to 1.0 (m/s)
+# odom0_pose_heading_gain_at_low_speed: 0.1    # Covariance scale factor at low speed; lower = less heading influence
+
 # Further input parameter examples
 odom1: example/another_odom
 odom1_config: [false, false, true,
@@ -137,6 +147,10 @@ odom1_relative: true
 odom1_queue_size: 2
 odom1_pose_rejection_threshold: 2
 odom1_twist_rejection_threshold: 0.2
+# odom1_pose_speed_dependent_heading_gain: false
+# odom1_pose_heading_gain_low_speed_mps: 0.5
+# odom1_pose_heading_gain_high_speed_mps: 1.5
+# odom1_pose_heading_gain_at_low_speed: 0.1
 odom1_nodelay: false
 
 pose0: example/pose
@@ -149,6 +163,11 @@ pose0_differential: true
 pose0_relative: false
 pose0_queue_size: 5
 pose0_rejection_threshold: 2  # Note the difference in parameter name
+# [ADVANCED] Speed-dependent heading gain for pose topics (note: no '_pose_' infix, unlike odom topics)
+# pose0_speed_dependent_heading_gain: false
+# pose0_heading_gain_low_speed_mps: 0.5
+# pose0_heading_gain_high_speed_mps: 1.5
+# pose0_heading_gain_at_low_speed: 0.1
 pose0_nodelay: false
 
 twist0: example/twist

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -35,6 +35,7 @@
 
 #include <XmlRpcException.h>
 
+#include <cmath>
 #include <iomanip>
 #include <limits>
 #include <sstream>
@@ -182,6 +183,28 @@ namespace RobotLocalization
     measurementCovarianceSubset.setZero();
     prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
                    kalmanGainSubset, hphrInv, stateToMeasurementSubset);
+
+    if (measurement.speedDependentHeadingGain_)
+    {
+      const double lowSpeed = measurement.headingGainLowSpeedMps_;
+      const double highSpeed = measurement.headingGainHighSpeedMps_;
+      const double lowSpeedGain = std::fmin(1.0, std::fmax(0.0, measurement.headingGainAtLowSpeed_));
+      const double speed = std::hypot(state_(StateMemberVx), state_(StateMemberVy));
+      double headingGainScale = 1.0;
+
+      if (highSpeed > lowSpeed)
+      {
+        const double speedAlpha = std::fmin(1.0, std::fmax(0.0, (speed - lowSpeed) / (highSpeed - lowSpeed)));
+        headingGainScale = lowSpeedGain + (1.0 - lowSpeedGain) * speedAlpha;
+      }
+      else if (speed <= lowSpeed)
+      {
+        headingGainScale = lowSpeedGain;
+      }
+
+      kalmanGainSubset.row(StateMemberYaw) *= headingGainScale;
+      kalmanGainSubset.row(StateMemberVyaw) *= headingGainScale;
+    }
 
     double sqMahalanobis = getSquaredMahalanobisDistance(innovationSubset, hphrInv);
     FB_DEBUG("Squared Mahalanobis is: " << sqMahalanobis << "\n" <<
@@ -413,4 +436,3 @@ namespace RobotLocalization
   }
 
 }  // namespace RobotLocalization
-

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -184,7 +184,7 @@ namespace RobotLocalization
     prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
                    kalmanGainSubset, hphrInv, stateToMeasurementSubset);
 
-    if (measurement.speedDependentHeadingGain_)
+    if (measurement.isSpeedDependentHeadingGainEnabled_)
     {
       const double lowSpeed = measurement.headingGainLowSpeedMps_;
       const double highSpeed = measurement.headingGainHighSpeedMps_;

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -374,12 +374,26 @@ namespace RobotLocalization
     meas->publishMahalanobisDistance_ = publishMahalanobisDistance;
     meas->mahalanobisThresh_ = mahalanobisThresh;
     meas->mahalanobisThreshInit_ = mahalanobisThreshInit;
-    if (speedDependentHeadingGainMap_.count(topicName) > 0)
+    const auto it = speedDependentHeadingGainMap_.find(topicName);
+    if (it != speedDependentHeadingGainMap_.end())
     {
-      meas->speedDependentHeadingGain_ = speedDependentHeadingGainMap_[topicName];
-      meas->headingGainLowSpeedMps_ = headingGainLowSpeedMpsMap_[topicName];
-      meas->headingGainHighSpeedMps_ = headingGainHighSpeedMpsMap_[topicName];
-      meas->headingGainAtLowSpeed_ = headingGainAtLowSpeedMap_[topicName];
+      const auto itLow = headingGainLowSpeedMpsMap_.find(topicName);
+      const auto itHigh = headingGainHighSpeedMpsMap_.find(topicName);
+      const auto itGain = headingGainAtLowSpeedMap_.find(topicName);
+
+      if (itLow != headingGainLowSpeedMpsMap_.end() &&
+          itHigh != headingGainHighSpeedMpsMap_.end() &&
+          itGain != headingGainAtLowSpeedMap_.end())
+      {
+        meas->speedDependentHeadingGain_ = it->second;
+        meas->headingGainLowSpeedMps_ = itLow->second;
+        meas->headingGainHighSpeedMps_ = itHigh->second;
+        meas->headingGainAtLowSpeed_ = itGain->second;
+      }
+      else
+      {
+        ROS_WARN_STREAM_THROTTLE(5.0, "Speed-dependent heading gain settings missing for " << topicName);
+      }
     }
     meas->latestControl_ = latestControl_;
     meas->latestControlTime_ = latestControlTime_.toSec();

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -374,21 +374,13 @@ namespace RobotLocalization
     meas->publishMahalanobisDistance_ = publishMahalanobisDistance;
     meas->mahalanobisThresh_ = mahalanobisThresh;
     meas->mahalanobisThreshInit_ = mahalanobisThreshInit;
-    const auto it = speedDependentHeadingGainMap_.find(topicName);
-    if (it != speedDependentHeadingGainMap_.end())
+    const auto it = headingGainSettingsMap_.find(topicName);
+    if (it != headingGainSettingsMap_.end())
     {
-      const auto itLow = headingGainLowSpeedMpsMap_.find(topicName);
-      const auto itHigh = headingGainHighSpeedMpsMap_.find(topicName);
-      const auto itGain = headingGainAtLowSpeedMap_.find(topicName);
-
-      if (itLow != headingGainLowSpeedMpsMap_.end() &&
-          itHigh != headingGainHighSpeedMpsMap_.end() &&
-          itGain != headingGainAtLowSpeedMap_.end())
-      {
-        meas->speedDependentHeadingGain_ = it->second;
-        meas->headingGainLowSpeedMps_ = itLow->second;
-        meas->headingGainHighSpeedMps_ = itHigh->second;
-        meas->headingGainAtLowSpeed_ = itGain->second;
+        meas->isSpeedDependentHeadingGainEnabled_ = it->second.isEnabled;
+        meas->headingGainLowSpeedMps_ = it->second.lowSpeedMps;
+        meas->headingGainHighSpeedMps_ = it->second.highSpeedMps;
+        meas->headingGainAtLowSpeed_ = it->second.gainAtLowSpeed;
       }
       else
       {
@@ -1296,10 +1288,28 @@ namespace RobotLocalization
         nhLocal_.param(odomTopicName + std::string("_pose_heading_gain_at_low_speed"),
                  poseHeadingGainAtLowSpeed,
                  1.0);
-        speedDependentHeadingGainMap_[odomTopicName + "_pose"] = poseSpeedDependentHeadingGain;
-        headingGainLowSpeedMpsMap_[odomTopicName + "_pose"] = poseHeadingGainLowSpeedMps;
-        headingGainHighSpeedMpsMap_[odomTopicName + "_pose"] = poseHeadingGainHighSpeedMps;
-        headingGainAtLowSpeedMap_[odomTopicName + "_pose"] = poseHeadingGainAtLowSpeed;
+        
+        // Validate heading gain settings
+        if (poseSpeedDependentHeadingGain)
+        {
+          if (poseHeadingGainAtLowSpeed < 0.0 || poseHeadingGainAtLowSpeed > 1.0)
+          {
+            ROS_WARN_STREAM("Heading gain at low speed for " << odomTopicName << " is " << 
+              poseHeadingGainAtLowSpeed << ", which is outside [0, 1]. Clamping to valid range.");
+            poseHeadingGainAtLowSpeed = std::max(0.0, std::min(1.0, poseHeadingGainAtLowSpeed));
+          }
+          if (poseHeadingGainLowSpeedMps > poseHeadingGainHighSpeedMps)
+          {
+            ROS_WARN_STREAM("Low speed threshold (" << poseHeadingGainLowSpeedMps << " m/s) is greater than "
+              "high speed threshold (" << poseHeadingGainHighSpeedMps << " m/s) for " << odomTopicName << 
+              ". Check your configuration.");
+          }
+        }
+        
+        headingGainSettingsMap_[odomTopicName + "_pose"] = {poseSpeedDependentHeadingGain,
+                                                             poseHeadingGainLowSpeedMps,
+                                                             poseHeadingGainHighSpeedMps,
+                                                             poseHeadingGainAtLowSpeed};
 
         // Check for twist rejection threshold
         if (publishMahalanobisDistance)
@@ -1491,10 +1501,28 @@ namespace RobotLocalization
         nhLocal_.param(poseTopicName + std::string("_heading_gain_at_low_speed"),
                  poseHeadingGainAtLowSpeed,
                  1.0);
-        speedDependentHeadingGainMap_[poseTopicName] = poseSpeedDependentHeadingGain;
-        headingGainLowSpeedMpsMap_[poseTopicName] = poseHeadingGainLowSpeedMps;
-        headingGainHighSpeedMpsMap_[poseTopicName] = poseHeadingGainHighSpeedMps;
-        headingGainAtLowSpeedMap_[poseTopicName] = poseHeadingGainAtLowSpeed;
+        
+        // Validate heading gain settings
+        if (poseSpeedDependentHeadingGain)
+        {
+          if (poseHeadingGainAtLowSpeed < 0.0 || poseHeadingGainAtLowSpeed > 1.0)
+          {
+            ROS_WARN_STREAM("Heading gain at low speed for " << poseTopicName << " is " << 
+              poseHeadingGainAtLowSpeed << ", which is outside [0, 1]. Clamping to valid range.");
+            poseHeadingGainAtLowSpeed = std::max(0.0, std::min(1.0, poseHeadingGainAtLowSpeed));
+          }
+          if (poseHeadingGainLowSpeedMps > poseHeadingGainHighSpeedMps)
+          {
+            ROS_WARN_STREAM("Low speed threshold (" << poseHeadingGainLowSpeedMps << " m/s) is greater than "
+              "high speed threshold (" << poseHeadingGainHighSpeedMps << " m/s) for " << poseTopicName << 
+              ". Check your configuration.");
+          }
+        }
+        
+        headingGainSettingsMap_[poseTopicName] = {poseSpeedDependentHeadingGain,
+                                                   poseHeadingGainLowSpeedMps,
+                                                   poseHeadingGainHighSpeedMps,
+                                                   poseHeadingGainAtLowSpeed};
 
         int poseQueueSize = 1;
         nhLocal_.param(poseTopicName + "_queue_size", poseQueueSize, 1);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -374,6 +374,13 @@ namespace RobotLocalization
     meas->publishMahalanobisDistance_ = publishMahalanobisDistance;
     meas->mahalanobisThresh_ = mahalanobisThresh;
     meas->mahalanobisThreshInit_ = mahalanobisThreshInit;
+    if (speedDependentHeadingGainMap_.count(topicName) > 0)
+    {
+      meas->speedDependentHeadingGain_ = speedDependentHeadingGainMap_[topicName];
+      meas->headingGainLowSpeedMps_ = headingGainLowSpeedMpsMap_[topicName];
+      meas->headingGainHighSpeedMps_ = headingGainHighSpeedMpsMap_[topicName];
+      meas->headingGainAtLowSpeed_ = headingGainAtLowSpeedMap_[topicName];
+    }
     meas->latestControl_ = latestControl_;
     meas->latestControlTime_ = latestControlTime_.toSec();
     measurementQueue_.push(meas);
@@ -1259,6 +1266,26 @@ namespace RobotLocalization
         nhLocal_.param(odomTopicName + std::string("_pose_rejection_threshold_trusted"),
                        poseMahalanobisThreshTrusted,
                        std::numeric_limits<double>::max());
+        bool poseSpeedDependentHeadingGain;
+        nhLocal_.param(odomTopicName + std::string("_pose_speed_dependent_heading_gain"),
+                 poseSpeedDependentHeadingGain,
+                 false);
+        double poseHeadingGainLowSpeedMps;
+        nhLocal_.param(odomTopicName + std::string("_pose_heading_gain_low_speed_mps"),
+                 poseHeadingGainLowSpeedMps,
+                 0.0);
+        double poseHeadingGainHighSpeedMps;
+        nhLocal_.param(odomTopicName + std::string("_pose_heading_gain_high_speed_mps"),
+                 poseHeadingGainHighSpeedMps,
+                 0.0);
+        double poseHeadingGainAtLowSpeed;
+        nhLocal_.param(odomTopicName + std::string("_pose_heading_gain_at_low_speed"),
+                 poseHeadingGainAtLowSpeed,
+                 1.0);
+        speedDependentHeadingGainMap_[odomTopicName + "_pose"] = poseSpeedDependentHeadingGain;
+        headingGainLowSpeedMpsMap_[odomTopicName + "_pose"] = poseHeadingGainLowSpeedMps;
+        headingGainHighSpeedMpsMap_[odomTopicName + "_pose"] = poseHeadingGainHighSpeedMps;
+        headingGainAtLowSpeedMap_[odomTopicName + "_pose"] = poseHeadingGainAtLowSpeed;
 
         // Check for twist rejection threshold
         if (publishMahalanobisDistance)
@@ -1434,6 +1461,26 @@ namespace RobotLocalization
         nhLocal_.param(poseTopicName + std::string("_rejection_threshold_trusted"),
                        poseMahalanobisThreshTrusted,
                        std::numeric_limits<double>::max());
+        bool poseSpeedDependentHeadingGain;
+        nhLocal_.param(poseTopicName + std::string("_speed_dependent_heading_gain"),
+                 poseSpeedDependentHeadingGain,
+                 false);
+        double poseHeadingGainLowSpeedMps;
+        nhLocal_.param(poseTopicName + std::string("_heading_gain_low_speed_mps"),
+                 poseHeadingGainLowSpeedMps,
+                 0.0);
+        double poseHeadingGainHighSpeedMps;
+        nhLocal_.param(poseTopicName + std::string("_heading_gain_high_speed_mps"),
+                 poseHeadingGainHighSpeedMps,
+                 0.0);
+        double poseHeadingGainAtLowSpeed;
+        nhLocal_.param(poseTopicName + std::string("_heading_gain_at_low_speed"),
+                 poseHeadingGainAtLowSpeed,
+                 1.0);
+        speedDependentHeadingGainMap_[poseTopicName] = poseSpeedDependentHeadingGain;
+        headingGainLowSpeedMpsMap_[poseTopicName] = poseHeadingGainLowSpeedMps;
+        headingGainHighSpeedMpsMap_[poseTopicName] = poseHeadingGainHighSpeedMps;
+        headingGainAtLowSpeedMap_[poseTopicName] = poseHeadingGainAtLowSpeed;
 
         int poseQueueSize = 1;
         nhLocal_.param(poseTopicName + "_queue_size", poseQueueSize, 1);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -377,15 +377,14 @@ namespace RobotLocalization
     const auto it = headingGainSettingsMap_.find(topicName);
     if (it != headingGainSettingsMap_.end())
     {
-        meas->isSpeedDependentHeadingGainEnabled_ = it->second.isEnabled;
-        meas->headingGainLowSpeedMps_ = it->second.lowSpeedMps;
-        meas->headingGainHighSpeedMps_ = it->second.highSpeedMps;
-        meas->headingGainAtLowSpeed_ = it->second.gainAtLowSpeed;
-      }
-      else
-      {
-        ROS_WARN_STREAM_THROTTLE(5.0, "Speed-dependent heading gain settings missing for " << topicName);
-      }
+      meas->isSpeedDependentHeadingGainEnabled_ = it->second.isEnabled;
+      meas->headingGainLowSpeedMps_ = it->second.lowSpeedMps;
+      meas->headingGainHighSpeedMps_ = it->second.highSpeedMps;
+      meas->headingGainAtLowSpeed_ = it->second.gainAtLowSpeed;
+    }
+    else
+    {
+      ROS_WARN_STREAM_THROTTLE(5.0, "Speed-dependent heading gain settings missing for " << topicName);
     }
     meas->latestControl_ = latestControl_;
     meas->latestControlTime_ = latestControlTime_.toSec();

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -293,7 +293,7 @@ namespace RobotLocalization
     prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
                    kalmanGainSubset, invInnovCov, predictedMeasCovar);
 
-    if (measurement.speedDependentHeadingGain_)
+    if (measurement.isSpeedDependentHeadingGainEnabled_)
     {
       const double lowSpeed = measurement.headingGainLowSpeedMps_;
       const double highSpeed = measurement.headingGainHighSpeedMps_;

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -37,6 +37,7 @@
 #include <assert.h>
 #include <Eigen/Cholesky>
 
+#include <cmath>
 #include <vector>
 
 
@@ -291,6 +292,28 @@ namespace RobotLocalization
     measurementCovarianceSubset.setZero();
     prepareCorrect(measurement, updateIndices, innovationSubset, measurementCovarianceSubset,
                    kalmanGainSubset, invInnovCov, predictedMeasCovar);
+
+    if (measurement.speedDependentHeadingGain_)
+    {
+      const double lowSpeed = measurement.headingGainLowSpeedMps_;
+      const double highSpeed = measurement.headingGainHighSpeedMps_;
+      const double lowSpeedGain = std::fmin(1.0, std::fmax(0.0, measurement.headingGainAtLowSpeed_));
+      const double speed = std::hypot(state_(StateMemberVx), state_(StateMemberVy));
+      double headingGainScale = 1.0;
+
+      if (highSpeed > lowSpeed)
+      {
+        const double speedAlpha = std::fmin(1.0, std::fmax(0.0, (speed - lowSpeed) / (highSpeed - lowSpeed)));
+        headingGainScale = lowSpeedGain + (1.0 - lowSpeedGain) * speedAlpha;
+      }
+      else if (speed <= lowSpeed)
+      {
+        headingGainScale = lowSpeedGain;
+      }
+
+      kalmanGainSubset.row(StateMemberYaw) *= headingGainScale;
+      kalmanGainSubset.row(StateMemberVyaw) *= headingGainScale;
+    }
 
     double sqMahalanobis = getSquaredMahalanobisDistance(innovationSubset, invInnovCov);
     FB_DEBUG("Squared Mahalanobis is: " << sqMahalanobis << "\n" <<


### PR DESCRIPTION
This PR adds a feature that scales the kalman gain effecting yaw and v_yaw based on GPS measurements when linear velocity is low. This is being done mainly to attenuate a feedback loop between navsat_transform and robot_localization that causes the yaw estimate to drift when our mowers are coming to a stop. GPS should not effect yaw significantly at low or zero speed since it contains little to no information in these cases. However the output of robot_localization informs navsat_transform of rotation, which then transforms GPS measurements into the base frame using it. This means that navsat_transform informs robot_localization that it is moving on an arc with length equal to the offset between the GPS receiver and base frame. The motion is perpendicular to the heading of the mower, which informs robot_localization that the heading is 90 degrees offset from the correct heading and pulls the estimate in that direction.

This feature defaults to being disabled so it does not have any effect unless enabled.