### PR TITLE
Remove speed-dependent heading gain parameter warning

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -382,10 +382,6 @@ namespace RobotLocalization
       meas->headingGainHighSpeedMps_ = it->second.highSpeedMps;
       meas->headingGainAtLowSpeed_ = it->second.gainAtLowSpeed;
     }
-    else
-    {
-      ROS_WARN_STREAM_THROTTLE(5.0, "Speed-dependent heading gain settings missing for " << topicName);
-    }
     meas->latestControl_ = latestControl_;
     meas->latestControlTime_ = latestControlTime_.toSec();
     measurementQueue_.push(meas);


### PR DESCRIPTION
The `Speed-dependent heading gain settings missing for ...` warning is spamming our ROS logs for twist topics. But speed-dependent heading gain is not applicable to twist topics and all the speed-dependent heading parameters are set to have default values for pose topics, so I don't think this warn is useful. So this PR removes the ROS WARN.